### PR TITLE
wallet: add option to delete wallet

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -189,17 +189,6 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
         });
     }
 
-    private void restartApp() {
-        PackageManager packageManager = getPackageManager();
-        Intent intent = packageManager.getLaunchIntentForPackage(getPackageName());
-        if (intent != null) {
-            ComponentName componentName = intent.getComponent();
-            Intent mainIntent = Intent.makeRestartActivityTask(componentName);
-            startActivity(mainIntent);
-            Runtime.getRuntime().exit(0);
-        }
-    }
-
     private void registerNotificationChannel() {
         notificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -235,7 +224,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
 
         if (constants.wallet == null) {
             System.out.println("Restarting app");
-            restartApp();
+            Utils.restartApp(this);
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/com/dcrandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/SettingsActivity.java
@@ -1,6 +1,7 @@
 package com.dcrandroid.activities;
 
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
@@ -19,6 +20,7 @@ import android.widget.Toast;
 import com.dcrandroid.BuildConfig;
 import com.dcrandroid.R;
 import com.dcrandroid.data.Constants;
+import com.dcrandroid.dialog.DeleteWalletDialog;
 import com.dcrandroid.dialog.StakeyDialog;
 import com.dcrandroid.util.DcrConstants;
 import com.dcrandroid.util.PreferenceUtil;
@@ -43,6 +45,7 @@ public class SettingsActivity extends AppCompatActivity {
 
     public static class MainPreferenceFragment extends PreferenceFragmentCompat {
         private final int ENCRYPT_REQUEST_CODE = 1;
+        private final int PASSCODE_REQUEST_CODE = 2;
         private PreferenceUtil util;
         private int buildDateClicks = 0;
         private SwitchPreference encryptWallet;
@@ -307,6 +310,58 @@ public class SettingsActivity extends AppCompatActivity {
                                 }
                             }).setNegativeButton(android.R.string.cancel, null)
                             .show();
+                            return true;
+                }
+            });
+        
+            findPreference(getString(R.string.delete_wallet)).setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    final DeleteWalletDialog deleteWalletDialog = new DeleteWalletDialog(getContext());
+                    deleteWalletDialog.setTitle(getString(R.string.delete_wallet_prompt_title));
+                    deleteWalletDialog.setMessage(getString(R.string.delete_wallet_prompt_message));
+                    deleteWalletDialog.setCancelable(true);
+                    deleteWalletDialog.setPositiveButton(new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (util.get(Constants.SPENDING_PASSPHRASE_TYPE).equals(Constants.PIN)) {
+                                startActivityForResult(new Intent(getActivity(), EnterPassCode.class), PASSCODE_REQUEST_CODE);
+                            } else {
+                                pd = Utils.getProgressDialog(getContext(), false, false, "Deleting Wallet . . .");
+                                pd.show();
+                                new Thread() {
+                                    public void run() {
+                                        try {
+                                            DcrConstants.getInstance().wallet.unlockWallet(deleteWalletDialog.getPassphrase().getBytes());
+                                            if (getActivity() != null) {
+                                                Utils.clearApplicationData(getActivity());
+                                                getActivity().runOnUiThread(new Runnable() {
+                                                    @Override
+                                                    public void run() {
+                                                        pd.dismiss();
+                                                        Utils.restartApp(getContext());
+                                                    }
+                                                });
+                                            }
+                                        } catch (final Exception e) {
+                                            e.printStackTrace();
+                                            if (getActivity() != null) {
+                                                getActivity().runOnUiThread(new Runnable() {
+                                                    @Override
+                                                    public void run() {
+                                                        deleteWalletDialog.dismiss();
+                                                        Toast.makeText(getActivity(), getString(R.string.invalid_passphrase), Toast.LENGTH_LONG).show();
+                                                        pd.dismiss();
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    }
+                                }.start();
+                            }
+                        }
+                    }).show();
+                    deleteWalletDialog.show();
                     return true;
                 }
             });
@@ -353,6 +408,21 @@ public class SettingsActivity extends AppCompatActivity {
                     } else {
                         encryptWallet.setChecked(!encryptWallet.isChecked());
                         changeEncryptionPass.setVisible(encryptWallet.isChecked());
+                    }
+                }
+            } else if (requestCode == PASSCODE_REQUEST_CODE) {
+                if (resultCode == RESULT_OK) {
+                    pd = Utils.getProgressDialog(getContext(), false, false, "Deleting Wallet . . .");
+                    pd.show();
+                    if (getActivity() != null) {
+                        Utils.clearApplicationData(getActivity());
+                        getActivity().runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                pd.dismiss();
+                                Utils.restartApp(getActivity());
+                            }
+                        });
                     }
                 }
             }

--- a/app/src/main/java/com/dcrandroid/activities/TransactionDetailsActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/TransactionDetailsActivity.java
@@ -84,17 +84,6 @@ public class TransactionDetailsActivity extends AppCompatActivity {
         listView.requestLayout();
     }
 
-    private void restartApp() {
-        PackageManager packageManager = getPackageManager();
-        Intent intent = packageManager.getLaunchIntentForPackage(getPackageName());
-        if (intent != null) {
-            ComponentName componentName = intent.getComponent();
-            Intent mainIntent = Intent.makeRestartActivityTask(componentName);
-            startActivity(mainIntent);
-            Runtime.getRuntime().exit(0);
-        }
-    }
-
     @Override
     public boolean onSupportNavigateUp() {
         finish();
@@ -106,7 +95,7 @@ public class TransactionDetailsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         if (DcrConstants.getInstance().wallet == null) {
-            restartApp();
+            Utils.restartApp(this);
             return;
         }
 

--- a/app/src/main/java/com/dcrandroid/dialog/DeleteWalletDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/DeleteWalletDialog.kt
@@ -1,0 +1,102 @@
+package com.dcrandroid.dialog
+
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.support.v4.content.ContextCompat
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.View
+import android.view.Window
+import android.widget.TextView
+import com.dcrandroid.R
+import com.dcrandroid.data.Constants
+import com.dcrandroid.util.PreferenceUtil
+import kotlinx.android.synthetic.main.confirm_tx_dialog.*
+
+class DeleteWalletDialog(context: Context) : Dialog(context), View.OnClickListener {
+    private var btnPositiveClick: DialogInterface.OnClickListener? = null
+
+    private var title: String? = null
+
+    private var message: String? = null
+
+
+    @SuppressLint("SetTextI18n")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        setContentView(R.layout.delete_wallet_dialog)
+
+        findViewById<TextView>(R.id.btn_positive).setOnClickListener(this)
+        findViewById<TextView>(R.id.btn_negative).setOnClickListener(this)
+
+        val tvTitle = findViewById<TextView>(R.id.title)
+
+        tvTitle.text = title
+
+        val tvMessage = findViewById<TextView>(R.id.message)
+        tvMessage.text = message
+
+        val util = PreferenceUtil(context)
+        if (util.get(Constants.SPENDING_PASSPHRASE_TYPE) == Constants.PIN) {
+            passphrase_input.visibility = View.GONE
+            btn_positive.isEnabled = true
+            btn_positive.setTextColor(ContextCompat.getColor(getContext(), R.color.blue))
+        } else {
+            passphrase_input.addTextChangedListener(passphraseTextWatcher)
+        }
+    }
+
+    fun setPositiveButton(listener: DialogInterface.OnClickListener?): DeleteWalletDialog {
+        btnPositiveClick = listener
+        return this
+    }
+
+    fun setTitle(title: String): DeleteWalletDialog {
+        this.title = title
+        return this
+    }
+
+    fun setMessage(message: String): DeleteWalletDialog {
+        this.message = message
+        return this
+    }
+
+    fun getPassphrase(): String {
+        return passphrase_input.text.toString()
+    }
+
+    override fun onClick(v: View?) {
+        when (v!!.id) {
+            R.id.btn_negative -> {
+                cancel()
+            }
+            R.id.btn_positive -> {
+                dismiss()
+                if (btnPositiveClick != null) {
+                    btnPositiveClick?.onClick(this, DialogInterface.BUTTON_POSITIVE)
+                }
+            }
+        }
+    }
+
+    private val passphraseTextWatcher: TextWatcher = object : TextWatcher {
+        override fun afterTextChanged(s: Editable?) {
+            if (passphrase_input.text.isNullOrEmpty()) {
+                btn_positive.isEnabled = false
+                btn_positive.setTextColor(ContextCompat.getColor(getContext(), R.color.lightGreyBackgroundColor))
+            } else {
+                btn_positive.isEnabled = true
+                btn_positive.setTextColor(ContextCompat.getColor(getContext(), R.color.blue))
+            }
+        }
+
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+    }
+}

--- a/app/src/main/java/com/dcrandroid/util/Utils.java
+++ b/app/src/main/java/com/dcrandroid/util/Utils.java
@@ -1,8 +1,13 @@
 package com.dcrandroid.util;
 
 import android.app.ProgressDialog;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.preference.PreferenceManager;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -413,5 +418,45 @@ public class Utils {
 
     private static double log2(double a) {
         return Math.log(a) / Math.log(2);
+    }
+
+    public static void clearApplicationData(Context context) {
+        File cache = context.getCacheDir();
+        File appDir = new File(cache.getParent());
+        if (appDir.exists()) {
+            String[] children = appDir.list();
+            for (String s : children) {
+                if (!s.equals("lib")) {
+                    deleteDir(new File(appDir, s));
+                }
+            }
+        }
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        sp.edit().clear().commit();
+    }
+
+    static boolean deleteDir(File dir) {
+        if (dir != null && dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i = 0; i < children.length; i++) {
+                boolean success = deleteDir(new File(dir, children[i]));
+                if (!success) {
+                    return false;
+                }
+            }
+        }
+        assert dir != null;
+        return dir.delete();
+    }
+
+    public static void restartApp(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        Intent intent = packageManager.getLaunchIntentForPackage(context.getPackageName());
+        if (intent != null) {
+            ComponentName componentName = intent.getComponent();
+            Intent mainIntent = Intent.makeRestartActivityTask(componentName);
+            context.startActivity(mainIntent);
+            Runtime.getRuntime().exit(0);
+        }
     }
 }

--- a/app/src/main/res/layout/delete_wallet_dialog.xml
+++ b/app/src/main/res/layout/delete_wallet_dialog.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="280dp"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingLeft="8dp"
+        android:paddingRight="8dp">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:textColor="@color/greenLightTextColor"
+            android:textSize="18sp"
+            app:fontFamily="@font/source_sans_pro_regular_family" />
+
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/blueGrayFirstTextColor"
+            android:textSize="16sp"
+            app:fontFamily="@font/source_sans_pro_regular_family" />
+
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/passphrase_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:layout_marginTop="16dp">
+
+            <android.support.v7.widget.AppCompatEditText
+                android:id="@+id/passphrase_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/toConfirmEnterYourPassword"
+                android:inputType="textPassword"
+                android:singleLine="true"
+                android:textColor="@color/blackFirstTextColor"
+                android:textColorHint="@color/grayTextColor"
+                android:textStyle="normal" />
+
+        </android.support.design.widget.TextInputLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/btn_layout"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:background="@color/colorPrimary"
+        android:weightSum="2">
+
+        <TextView
+            android:id="@+id/btn_negative"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="?android:attr/selectableItemBackground"
+            android:gravity="center"
+            android:textAllCaps="true"
+            android:textColor="@color/darkBlueTextColor"
+            android:textSize="14sp"
+            android:visibility="visible"
+            android:text="@string/no"
+            app:fontFamily="@font/source_sans_pro_semibold_family" />
+
+        <TextView
+            android:id="@+id/btn_positive"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="?android:attr/selectableItemBackground"
+            android:enabled="false"
+            android:gravity="center"
+            android:textAllCaps="true"
+            android:textColor="@color/lightGreyBackgroundColor"
+            android:textSize="14sp"
+            android:visibility="visible"
+            android:text="@string/delete"
+            app:fontFamily="@font/source_sans_pro_semibold_family" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,8 @@
     <string name="https_docs_decred_org" translatable="false">https://docs.decred.org</string>
     <string name="exit_app_prompt_title">Exit wallet?</string>
     <string name="exit_app_prompt_message">Are you sure you want to exit?</string>
+    <string name="delete_wallet_prompt_title">Delete Wallet?</string>
+    <string name="delete_wallet_prompt_message">Are you sure you want to delete your wallet? Make sure you have your wallet seed saved or your coins moved before deleting. This will also clear all app settings to a default state.</string>
     <string name="details">Details</string>
     <string name="setting">Setting</string>
     <string name="hide_this_account">Hide This Account</string>
@@ -52,6 +54,7 @@
     <string name="exit_cap">EXIT</string>
     <string name="hidden">hidden</string>
     <string name="delete">Delete</string>
+    <string name="no">No</string>
     <string name="confirm">Confirm</string>
     <string name="usd" translatable="false">USD</string>
     <string name="hyphen">-</string>
@@ -287,6 +290,8 @@
     <string name="remote_node_address" translatable="false">remote_node_address</string>
     <string name="unconfirmed_funds">Spend Unconfirmed Funds</string>
     <string name="build_date_system" translatable="false">build_date_system</string>
+    <string name="delete_wallet" translatable="false">delete_wallet</string>
+    <string name="delete_wallet_title">Delete Wallet</string>
     <string name="logging_level">Logging Level</string>
     <string name="network_mode">Network Mode</string>
     <string name="connect_to_peer">Connect to Peer</string>

--- a/app/src/main/res/xml/pref_main.xml
+++ b/app/src/main/res/xml/pref_main.xml
@@ -119,5 +119,10 @@
             android:title="@string/build_date"
             app:iconSpaceReserved="false"
             />
+        <Preference
+            android:key="@string/delete_wallet"
+            android:title="@string/delete_wallet_title"
+            app:iconSpaceReserved="false"
+            />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
An option was included in settings that allows users delete their wallet.
Deleting wallet creates a full app reset.

Highlights:
- Delete wallet option in settings
- Confirmation to delete wallet
- Password/PIN verification before deletion
- After deletion, the app is restarted.

This closes #182 