### PR TITLE
build: fix conflicting provider at installation.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -129,7 +129,7 @@
             android:launchMode="singleInstance"/>
         <provider
             android:name="android.support.v4.content.FileProvider"
-            android:authorities="com.decred.dcrandroid.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:grantUriPermissions="true"
             android:exported="false">
             <meta-data


### PR DESCRIPTION
This fixes a conflict caused by using same file provider for testnet
and mainnet versions.