### PR TITLE
ui: remove unnecessary space from transaction input

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -33,6 +33,7 @@ import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -133,6 +134,11 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
 
         if (BuildConfig.IS_TESTNET) {
             findViewById(R.id.tv_testnet).setVisibility(View.VISIBLE);
+        }else{
+            ImageView decredSymbol = findViewById(R.id.nav_bar_logo);
+            LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) decredSymbol.getLayoutParams();
+            params.bottomMargin = (int) getResources().getDimension(R.dimen.mainnet_logo_bottom_margin);
+            decredSymbol.setLayoutParams(params);
         }
 
         mListView = findViewById(R.id.lv_nav);

--- a/app/src/main/java/com/dcrandroid/adapter/TransactionInfoAdapter.java
+++ b/app/src/main/java/com/dcrandroid/adapter/TransactionInfoAdapter.java
@@ -40,8 +40,8 @@ public class TransactionInfoAdapter extends ArrayAdapter<TransactionInfoAdapter.
         TextView tvAmount = listItem.findViewById(R.id.tvAmount);
         tvAmount.setText(transactionInfoItem.getAmount());
 
+        final TextView tvInfo = listItem.findViewById(R.id.tvInfo);
         if(transactionInfoItem.getInfo() != null && !transactionInfoItem.getInfo().trim().equals("")) {
-            final TextView tvInfo = listItem.findViewById(R.id.tvInfo);
             tvInfo.setText(transactionInfoItem.getInfo());
             tvInfo.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -49,6 +49,8 @@ public class TransactionInfoAdapter extends ArrayAdapter<TransactionInfoAdapter.
                     Utils.copyToClipboard(mContext, tvInfo.getText().toString(), mContext.getString(R.string.copied_to_clipboard));
                 }
             });
+        }else{
+            tvInfo.setVisibility(View.GONE);
         }
         return listItem;
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,6 +31,7 @@
             android:paddingTop="10dp"
             android:paddingBottom="10dp"
             android:background="@color/whiteFirstBackgroundColor">
+
             <ImageView
                 android:id="@+id/nav_bar_logo"
                 android:layout_width="200dp"

--- a/app/src/main/res/layout/list_item_adapter.xml
+++ b/app/src/main/res/layout/list_item_adapter.xml
@@ -5,6 +5,8 @@
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
     android:paddingStart="8dp"
     android:paddingLeft="8dp"
     android:paddingRight="8dp">
@@ -24,7 +26,6 @@
         android:layout_height="wrap_content"
         app:fontFamily="@font/roboto_regular"
         android:textColor="@color/blueLinkTextColor"
-        android:paddingBottom="10dp"
         android:textSize="14sp"
         tools:text="test text" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -17,4 +17,6 @@
     <dimen name="pinview_pin_size">30dp</dimen>
     <dimen name="pinview_horizontal_spacing">10dp</dimen>
     <dimen name="appbar_padding_top">8dp</dimen>
+
+    <dimen name="mainnet_logo_bottom_margin">5dp</dimen>
 </resources>


### PR DESCRIPTION
Remove unnecessary space from transaction input and increase mainnet logo bottom margin by 50%.
Closes #248 
<img width="308" alt="screenshot 2018-12-23 at 10 33 17 am" src="https://user-images.githubusercontent.com/19960200/50382456-b05d9300-069f-11e9-9455-2f1b64f263a6.png">
