### PR TITLE
Disable backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
     <application
         android:name=".MainApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="${appIcon}"
         android:label="@string/app_name"
         android:largeHeap="true"


### PR DESCRIPTION
Having backups enabled allows application data to be synced to Google's servers so it can be restored on other devices as well as enabling adb backups. In my view the only way the wallet should be restorable is if the user is in possession of the seed.

Most popular crypto wallets have this setting disabled.

Bitcoin Wallet
https://github.com/bitcoin-wallet/bitcoin-wallet/blob/master/wallet/AndroidManifest.xml#L62

Samurai Wallet
https://github.com/Samourai-Wallet/samourai-wallet-android/blob/develop/app/src/main/AndroidManifest.xml#L41

Copay
https://github.com/bitpay/copay/blob/3b98c82f2e078541f80790e04043ce0fea68e1e5/app-template/config-template.xml#L130

Monerujo
https://github.com/m2049r/xmrwallet/blob/master/app/src/main/AndroidManifest.xml#L17

