### PR TITLE
UI: add send/receive button to home screen

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -494,6 +494,16 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
         mListView.setItemChecked(1, true);
     }
 
+    public void displaySend() {
+        switchFragment(2);
+        mListView.setItemChecked(2, true);
+    }
+
+    public void displayReceive() {
+        switchFragment(3);
+        mListView.setItemChecked(3, true);
+    }
+
     @Override
     public void onTransaction(String s) {
         System.out.println("Notification Received: " + s);

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -114,6 +114,20 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, GetTr
             }
         }
 
+        send.setOnClickListener {
+            if (activity != null && activity is MainActivity) {
+                val mainActivity = activity as MainActivity?
+                mainActivity!!.displaySend()
+            }
+        }
+
+        receive.setOnClickListener {
+            if (activity != null && activity is MainActivity) {
+                val mainActivity = activity as MainActivity?
+                mainActivity!!.displayReceive()
+            }
+        }
+
         val vto = history_recycler_view2.viewTreeObserver
         if (vto.isAlive) {
             vto.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {

--- a/app/src/main/res/layout/content_overview.xml
+++ b/app/src/main/res/layout/content_overview.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/colorPrimary">
+    android:background="@color/colorPrimary"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -106,16 +106,49 @@
                 </LinearLayout>
             </android.support.v4.widget.SwipeRefreshLayout>
         </LinearLayout>
+
         <TextView
             android:id="@+id/show_history"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginBottom="40dp"
+            android:layout_marginBottom="10dp"
             android:padding="2dp"
             android:text="@string/show_all_transactions"
             android:textColor="@color/blueGraySecondTextColor"
             android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp">
+
+            <Button
+                android:id="@+id/send"
+                android:layout_width="0dp"
+                android:layout_height="60dp"
+                android:layout_margin="5dp"
+                android:layout_weight="0.5"
+                android:drawableStart="@mipmap/send"
+                android:drawableLeft="@mipmap/send"
+                android:drawablePadding="-25dp"
+                android:text="@string/send"
+                android:textAllCaps="false"
+                android:textSize="18sp" />
+
+            <Button
+                android:id="@+id/receive"
+                android:layout_width="0dp"
+                android:layout_height="60dp"
+                android:layout_margin="5dp"
+                android:layout_weight="0.5"
+                android:drawableStart="@mipmap/receive"
+                android:drawableLeft="@mipmap/receive"
+                android:drawablePadding="-25dp"
+                android:text="@string/receive"
+                android:textAllCaps="false"
+                android:textSize="18sp" />
+        </LinearLayout>
 
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
This adds a properly styled send and receive button
to the overview fragment.
Clicking the buttons switches to the appropriate fragment.
Closes #181 

![screenshot_1546051208](https://user-images.githubusercontent.com/12461844/50544169-56078980-0bed-11e9-97a4-667a20d93347.png)
