### PR TITLE
multi: fix long pin app crash

### DIFF
--- a/app/src/main/java/com/dcrandroid/util/KeyPad.kt
+++ b/app/src/main/java/com/dcrandroid/util/KeyPad.kt
@@ -1,6 +1,7 @@
 package com.dcrandroid.util
 
 
+import android.support.v4.content.ContextCompat
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -23,7 +24,6 @@ class KeyPad(private val keypadLayout: LinearLayout, private val pinView: PinVie
     private var listener: KeyPadListener? = null
 
     init {
-
         val temp = arrayOf(R.id.keypad_0, R.id.keypad_1, R.id.keypad_2, R.id.keypad_3, R.id.keypad_4, R.id.keypad_5, R.id.keypad_6, R.id.keypad_7, R.id.keypad_8, R.id.keypad_9)
         this.keyIds = Arrays.asList(*temp)
         keys = ArrayList(keyIds.size)

--- a/app/src/main/java/com/dcrandroid/view/PinView.kt
+++ b/app/src/main/java/com/dcrandroid/view/PinView.kt
@@ -8,10 +8,12 @@ import android.graphics.RectF
 import android.util.AttributeSet
 import android.view.View
 import com.dcrandroid.R
+import android.text.TextPaint
 
 class PinView : View {
     private var activePaint: Paint? = null
     private var emptyPaint: Paint? = null
+    private var mTextPaint: TextPaint? = null
 
     var passCodeLength: Int = 0
         set(value) {
@@ -81,6 +83,12 @@ class PinView : View {
         emptyPaint!!.style = Paint.Style.FILL
         emptyPaint!!.color = inactiveColor
 
+        mTextPaint = TextPaint()
+        mTextPaint!!.isAntiAlias = true
+        mTextPaint!!.textSize = 21 * resources.displayMetrics.density
+        mTextPaint!!.textAlign = Paint.Align.CENTER
+        mTextPaint!!.color = activeColor
+
         circleRect = RectF()
         activeRect = RectF()
     }
@@ -102,43 +110,45 @@ class PinView : View {
         val usableWidth = width - (pl + pr)
         val usableHeight = height - (pt + pb)
 
-        var pinSize = initialPinSize;
+        val pinSize = initialPinSize
 
-        var totalPinWidth = pinSize + horizontalSpacing
+        val totalPinWidth = pinSize + horizontalSpacing
 
-        while ((totalPinWidth * passCodeLength) > usableWidth) {
-            pinSize *= 0.90F
-            totalPinWidth = pinSize + horizontalSpacing
-        }
+        if ((totalPinWidth * passCodeLength) > usableWidth) {
+            val xPos = usableWidth.toFloat() / 2
+            val yPos = (usableHeight / 2 - (mTextPaint!!.descent() + mTextPaint!!.ascent()) / 2)
+            canvas.drawText(passCodeLength.toString(), xPos, yPos, mTextPaint)
+        }else {
 
-        val totalContentWidth = pinSize + horizontalSpacing
-        var startX = (usableWidth / 2) - ((totalContentWidth / 2) * passCodeLength)
-        val startY = pt + usableHeight - pinSize
+            val totalContentWidth = pinSize + horizontalSpacing
+            var startX = (usableWidth / 2) - ((totalContentWidth / 2) * passCodeLength)
+            val startY = pt + usableHeight - pinSize
 
-        for (i in 1..passCodeLength) {
-            circleRect!!.left = startX
-            circleRect!!.top = startY
-            circleRect!!.right = startX + pinSize
-            circleRect!!.bottom = startY + pinSize
+            for (i in 1..passCodeLength) {
+                circleRect!!.left = startX
+                circleRect!!.top = startY
+                circleRect!!.right = startX + pinSize
+                circleRect!!.bottom = startY + pinSize
 
-            if (i <= passCodeLength) {
+                if (i <= passCodeLength) {
+                    canvas.drawArc(circleRect!!, startX, 360f, true, emptyPaint!!)
+
+                    val activePadding = pinSize * 0.15f
+
+                    activeRect!!.left = circleRect!!.left + activePadding
+                    activeRect!!.top = circleRect!!.top + activePadding
+                    activeRect!!.bottom = circleRect!!.bottom - activePadding
+                    activeRect!!.right = circleRect!!.right - activePadding
+
+                    canvas.drawArc(activeRect!!, activeRect!!.left, 360f, true, activePaint!!)
+
+                    startX += totalContentWidth
+                    continue
+                }
+
                 canvas.drawArc(circleRect!!, startX, 360f, true, emptyPaint!!)
-
-                val activePadding = pinSize * 0.15f
-
-                activeRect!!.left = circleRect!!.left + activePadding
-                activeRect!!.top = circleRect!!.top + activePadding
-                activeRect!!.bottom = circleRect!!.bottom - activePadding
-                activeRect!!.right = circleRect!!.right - activePadding
-
-                canvas.drawArc(activeRect!!, activeRect!!.left, 360f, true, activePaint!!)
-
                 startX += totalContentWidth
-                continue
             }
-
-            canvas.drawArc(circleRect!!, startX, 360f, true, emptyPaint!!)
-            startX += totalContentWidth
         }
     }
 }

--- a/app/src/main/res/drawable-v21/bg_circle_white.xml
+++ b/app/src/main/res/drawable-v21/bg_circle_white.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+
+    <item android:id="@android:id/mask">
+        <shape android:shape="oval">
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="#FFFFFF" />
+        </shape>
+    </item>
+
+</ripple>

--- a/app/src/main/res/drawable-v21/circular_transparent_ripple.xml
+++ b/app/src/main/res/drawable-v21/circular_transparent_ripple.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:colorControlHighlight">
+
+    <item android:id="@android:id/mask">
+        <shape android:shape="oval">
+            <solid android:color="?android:colorAccent" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+
+</ripple>

--- a/app/src/main/res/drawable/circular_transparent_ripple.xml
+++ b/app/src/main/res/drawable/circular_transparent_ripple.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@android:color/transparent"/>
+</shape>

--- a/app/src/main/res/layout/passcode.xml
+++ b/app/src/main/res/layout/passcode.xml
@@ -240,6 +240,7 @@
                         android:textColor="#48566E"
                         android:textSize="25sp"
                         android:textStyle="bold"
+                        android:background="@drawable/circular_transparent_ripple"
                         app:fontFamily="@font/source_sans_pro_regular_family" />
 
                     <TextView


### PR DESCRIPTION
This fixes a crash that occurs when the pin display exceeds the screen width.
This change replace the entered pin display with the number of pin entered and also adds a ripple background to keypad for better user experience.

Closes #283

![pin numero](https://user-images.githubusercontent.com/19960200/50550307-70357c00-0c6e-11e9-9877-0557aa8ebd14.gif)
