### PR TITLE
Popup changes

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
@@ -33,6 +33,7 @@ public class AddAccountActivity extends AppCompatActivity {
     private PreferenceUtil util;
     private final int PASSCODE_REQUEST_CODE = 2;
     private EditText accountName;
+    private EditText passphrase;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,7 +47,7 @@ public class AddAccountActivity extends AppCompatActivity {
         setContentView(R.layout.add_account_activity);
 
         accountName = findViewById(R.id.add_acc_name);
-        final EditText passphrase = findViewById(R.id.add_acc_passphrase);
+        passphrase = findViewById(R.id.add_acc_passphrase);
 
         util = new PreferenceUtil(this);
         if (util.get(Constants.SPENDING_PASSPHRASE_TYPE).equals(Constants.PIN)) {
@@ -101,7 +102,7 @@ public class AddAccountActivity extends AppCompatActivity {
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            Toast.makeText(AddAccountActivity.this, Utils.translateError(AddAccountActivity.this, e), Toast.LENGTH_LONG).show();
+                            passphrase.setError(Utils.translateError(AddAccountActivity.this, e));
                         }
                     });
                     setResult(RESULT_CANCELED);

--- a/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
@@ -61,11 +61,11 @@ public class AddAccountActivity extends AppCompatActivity {
                 final String privatePassphrase = passphrase.getText().toString();
                 final String name = accountName.getText().toString().trim();
                 if (name.equals("")) {
-                    Toast.makeText(AddAccountActivity.this, R.string.input_account_name, Toast.LENGTH_SHORT).show();
+                    accountName.setError(getString(R.string.input_account_name));
                 } else {
                     if (util.get(Constants.SPENDING_PASSPHRASE_TYPE).equals(Constants.PASSWORD)) {
                         if (privatePassphrase.equals("")) {
-                            Toast.makeText(AddAccountActivity.this, R.string.input_private_phrase, Toast.LENGTH_SHORT).show();
+                            passphrase.setError(getString(R.string.input_private_phrase));
                             return;
                         }
                         createAccount(name, privatePassphrase.getBytes());

--- a/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/AddAccountActivity.java
@@ -102,7 +102,7 @@ public class AddAccountActivity extends AppCompatActivity {
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            passphrase.setError(Utils.translateError(AddAccountActivity.this, e));
+                            Utils.showMessage(AddAccountActivity.this, Utils.translateError(AddAccountActivity.this, e), Toast.LENGTH_LONG);
                         }
                     });
                     setResult(RESULT_CANCELED);

--- a/app/src/main/java/com/dcrandroid/activities/EnterPasswordActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/EnterPasswordActivity.kt
@@ -55,7 +55,7 @@ class EnterPasswordActivity : AppCompatActivity() {
                     finish()
                 }
             } else {
-                Snackbar.make(it, tv_prompt.text, Snackbar.LENGTH_SHORT).show()
+                password.error = "Field cannot be empty"
             }
         }
     }

--- a/app/src/main/java/com/dcrandroid/activities/EnterPasswordActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/EnterPasswordActivity.kt
@@ -55,7 +55,7 @@ class EnterPasswordActivity : AppCompatActivity() {
                     finish()
                 }
             } else {
-                password.error = "Field cannot be empty"
+                password.error = getString(R.string.field_cannot_be_empty)
             }
         }
     }

--- a/app/src/main/java/com/dcrandroid/activities/TransactionDetailsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/TransactionDetailsActivity.kt
@@ -164,7 +164,7 @@ class TransactionDetailsActivity: AppCompatActivity() {
         }
 
         tvHash!!.setOnClickListener {
-            Utils.copyToClipboard(this@TransactionDetailsActivity, transaction!!.hash, getString(R.string.tx_hash_copy))
+            Utils.copyToClipboard(this@TransactionDetailsActivity, transaction!!.hash, R.string.tx_hash_copy)
         }
     }
 
@@ -295,9 +295,9 @@ class TransactionDetailsActivity: AppCompatActivity() {
                 }
 
                 if (item.direction === TransactionDetailsAdapter.TransactionDebitCredit.Direction.DEBIT) {
-                    Utils.copyToClipboard(this@TransactionDetailsActivity, item.info, getString(R.string.tx_hash_copy))
+                    Utils.copyToClipboard(this@TransactionDetailsActivity, item.info, R.string.tx_hash_copy)
                 } else {
-                    Utils.copyToClipboard(this@TransactionDetailsActivity, item.info, getString(R.string.address_copy_text))
+                    Utils.copyToClipboard(this@TransactionDetailsActivity, item.info, R.string.address_copy_text)
                 }
             }
 
@@ -314,8 +314,8 @@ class TransactionDetailsActivity: AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.tx_details_tx_hash -> Utils.copyToClipboard(this, transaction!!.hash, getString(R.string.tx_hash_copy))
-            R.id.tx_details_raw_tx -> Utils.copyToClipboard(this, transaction!!.raw, getString(R.string.raw_tx_copied))
+            R.id.tx_details_tx_hash -> Utils.copyToClipboard(this, transaction!!.hash, R.string.tx_hash_copy)
+            R.id.tx_details_raw_tx -> Utils.copyToClipboard(this, transaction!!.raw, R.string.raw_tx_copied)
             R.id.tx_viewOnDcrData -> {
                 val url = if(BuildConfig.IS_TESTNET) {
                     "https://testnet.dcrdata.org/tx/" + transaction!!.hash

--- a/app/src/main/java/com/dcrandroid/fragments/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/ChangePasswordFragment.kt
@@ -54,6 +54,14 @@ class ChangePasswordFragment : Fragment(), View.OnKeyListener {
         verifyPassword.setOnKeyListener(this)
 
         btn_ok.setOnClickListener {
+            if (password.text.isBlank()) {
+                password.error = getString(R.string.field_cannot_be_empty)
+                return@setOnClickListener
+            }
+            if (verifyPassword.text.isBlank()) {
+                verifyPassword.error = getString(R.string.field_cannot_be_empty)
+                return@setOnClickListener
+            }
             if (password.text.toString() == verifyPassword.text.toString()) {
                 changePassword(password.text.toString())
             } else {

--- a/app/src/main/java/com/dcrandroid/fragments/ReceiveFragment.java
+++ b/app/src/main/java/com/dcrandroid/fragments/ReceiveFragment.java
@@ -212,7 +212,7 @@ public class ReceiveFragment extends Fragment implements AdapterView.OnItemSelec
                 if (getContext() == null) {
                     return false;
                 }
-                Utils.copyToClipboard(getContext(), address.getText().toString(), getString(R.string.address_copy_text));
+                Utils.copyToClipboard(getContext(), address.getText().toString(), R.string.address_copy_text);
                 return true;
         }
         return false;

--- a/app/src/main/java/com/dcrandroid/fragments/SecurityFragment.java
+++ b/app/src/main/java/com/dcrandroid/fragments/SecurityFragment.java
@@ -187,7 +187,7 @@ public class SecurityFragment extends Fragment {
                         + "\n" + getString(R.string.message_colon) + " " + etMessage.getText().toString()
                         + "\n" + getString(R.string.signature_colon) + " " + etSignature.getText().toString();
 
-                Utils.copyToClipboard(v.getContext(), text, getString(R.string.copied_successfully));
+                Utils.copyToClipboard(v.getContext(), text, R.string.copied_successfully);
             }
         });
 

--- a/app/src/main/java/com/dcrandroid/fragments/SendFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/SendFragment.kt
@@ -591,7 +591,7 @@ class SendFragment : Fragment(), AdapterView.OnItemSelectedListener, GetExchange
                     }
                 })
                 .setMessageClickListener(View.OnClickListener {
-                    Utils.copyToClipboard(context, txHash, getString(R.string.tx_hash_copy))
+                    Utils.copyToClipboard(context, txHash, R.string.tx_hash_copy)
                 })
 
         dialog.setCancelable(true)

--- a/app/src/main/java/com/dcrandroid/util/Utils.java
+++ b/app/src/main/java/com/dcrandroid/util/Utils.java
@@ -358,8 +358,8 @@ public class Utils {
         TextView tv = vi.findViewById(android.R.id.message);
         tv.setText(successMessage);
         Toast toast = new Toast(ctx);
-        toast.setGravity(Gravity.TOP | Gravity.CENTER, 0, 50);
-        toast.setDuration(Toast.LENGTH_SHORT);
+        toast.setGravity(Gravity.BOTTOM | Gravity.CENTER, 0, 50);
+        toast.setDuration(Toast.LENGTH_LONG);
         toast.setView(vi);
         toast.show();
     }

--- a/app/src/main/java/com/dcrandroid/util/Utils.java
+++ b/app/src/main/java/com/dcrandroid/util/Utils.java
@@ -48,6 +48,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import androidx.annotation.IdRes;
+import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
 import dcrlibwallet.Dcrlibwallet;
 
@@ -334,9 +336,6 @@ public class Utils {
     }
 
     public static void copyToClipboard(Context ctx, String copyText, String successMessage) {
-        Resources r = ctx.getResources();
-        int margin25dp = Math.round(TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, 25, r.getDisplayMetrics()));
 
         int sdk = android.os.Build.VERSION.SDK_INT;
         if (sdk < android.os.Build.VERSION_CODES.HONEYCOMB) {
@@ -353,15 +352,12 @@ public class Utils {
                 clipboard.setPrimaryClip(clip);
         }
 
-        LayoutInflater inflater = (LayoutInflater) ctx.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        View vi = inflater.inflate(R.layout.toast, null);
-        TextView tv = vi.findViewById(android.R.id.message);
-        tv.setText(successMessage);
-        Toast toast = new Toast(ctx);
-        toast.setGravity(Gravity.BOTTOM | Gravity.CENTER, 0, 50);
-        toast.setDuration(Toast.LENGTH_LONG);
-        toast.setView(vi);
-        toast.show();
+        showMessage(ctx, successMessage, Toast.LENGTH_SHORT);
+
+    }
+
+    public static void copyToClipboard(Context ctx, String copyText, @StringRes int successMessage){
+        copyToClipboard(ctx, copyText, ctx.getString(successMessage));
     }
 
     public static String readFromClipboard(Context context) {
@@ -376,6 +372,18 @@ public class Utils {
                 return clipboard.getPrimaryClip().getItemAt(0).getText().toString();
         }
         return "";
+    }
+
+    public static void showMessage(Context ctx, String message, int duration){
+        LayoutInflater inflater = (LayoutInflater) ctx.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View vi = inflater.inflate(R.layout.toast, null);
+        TextView tv = vi.findViewById(android.R.id.message);
+        tv.setText(message);
+        Toast toast = new Toast(ctx);
+        toast.setGravity(Gravity.BOTTOM | Gravity.CENTER, 0, 50);
+        toast.setDuration(duration);
+        toast.setView(vi);
+        toast.show();
     }
 
     public static void backupWalletDB(final Context context) {

--- a/app/src/main/res/drawable/toast_bg.xml
+++ b/app/src/main/res/drawable/toast_bg.xml
@@ -7,6 +7,6 @@
 
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/deepBlackTextColor" />
-    <corners android:radius="40dp" />
+    <solid android:color="#102473" />
+    <corners android:radius="10dp" />
 </shape>

--- a/app/src/main/res/layout/add_account_activity.xml
+++ b/app/src/main/res/layout/add_account_activity.xml
@@ -39,7 +39,10 @@
             android:id="@+id/add_acc_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
             android:hint="@string/account_name"
             android:maxLines="1"
             android:inputType="textPersonName" />

--- a/app/src/main/res/layout/add_account_activity.xml
+++ b/app/src/main/res/layout/add_account_activity.xml
@@ -57,7 +57,7 @@
             android:id="@+id/add_acc_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="8dp"
+            android:layout_marginTop="32dp"
             android:background="@drawable/btn_shape"
             android:padding="5dp"
             android:text="@string/create_account"

--- a/app/src/main/res/layout/change_password.xml
+++ b/app/src/main/res/layout/change_password.xml
@@ -64,7 +64,7 @@
             android:layout_width="100dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="36dp"
             android:background="@drawable/btn_shape"
             android:text="@string/ok"
             android:textColor="@color/white" />

--- a/app/src/main/res/layout/info_dialog.xml
+++ b/app/src/main/res/layout/info_dialog.xml
@@ -8,7 +8,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="280dp"
+    android:layout_width="300dp"
     android:layout_height="wrap_content"
     android:background="@color/white"
     android:orientation="vertical">
@@ -25,10 +25,11 @@
         android:paddingBottom="10dp">
 
         <androidx.appcompat.widget.AppCompatImageView
+            android:layout_marginTop="8dp"
             android:id="@+id/icon"
             android:layout_width="60dp"
             android:layout_height="60dp"
-            android:visibility="gone" />
+            android:visibility="visible" />
 
         <TextView
             android:id="@+id/title"
@@ -40,6 +41,7 @@
             app:fontFamily="@font/source_sans_pro_regular_family" />
 
         <TextView
+            android:padding="8dp"
             android:id="@+id/message"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -53,6 +55,7 @@
 
     <LinearLayout
         android:id="@+id/view_layout"
+        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/toast.xml
+++ b/app/src/main/res/layout/toast.xml
@@ -5,23 +5,18 @@
   ~ license that can be found in the LICENSE file.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
-    android:background="@drawable/toast_bg">
-
-    <TextView
-        android:id="@android:id/message"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginHorizontal="24dp"
-        android:layout_marginVertical="15dp"
-        android:layout_gravity="center_horizontal"
-        app:fontFamily="sans-serif"
-        android:textSize="14sp"
-        android:textColor="@color/white" />
-
-</LinearLayout>
+    android:background="@drawable/toast_bg"
+    android:id="@android:id/message"
+    android:layout_gravity="center_horizontal"
+    app:fontFamily="sans-serif"
+    android:textSize="18sp"
+    android:textStyle="bold"
+    android:textColor="@color/white"
+    android:paddingTop="11dp"
+    android:paddingBottom="11dp"
+    android:paddingStart="14dp"
+    android:paddingEnd="14dp"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,7 +113,6 @@
     <string name="license">License</string>
     <string name="key_license" translatable="false">license</string>
     <string name="always">Always</string>
-    <string name="not_synced">Not Synced</string>
 
     <string-array name="nav_list_titles">
         <item>Overview</item>
@@ -537,6 +536,7 @@
     <string name="required_to_enter_app">Required to enter app.</string>
     <string name="changing_pin">Changing PIN…</string>
     <string name="security_page_wallet_sync">Please wait for your wallet to finish synchronizing.</string>
+    <string name="field_cannot_be_empty">Field cannot be empty</string>
     <!--/Security-->
 
     <!--Crash Report-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,7 +102,7 @@
     <string name="copied_successfully">Copied successfully.</string>
     <string name="all">All</string>
     <string name="re_establishing_connection">Re-establishing connection</string>
-    <string name="address_not_found">The address not found.</string>
+    <string name="address_not_found">Address not found.</string>
     <string name="copied_to_clipboard">Copied to clipboard</string>
     <string name="clearAll">Clear All</string>
     <string name="share">Share</string>
@@ -113,6 +113,7 @@
     <string name="license">License</string>
     <string name="key_license" translatable="false">license</string>
     <string name="always">Always</string>
+    <string name="not_synced">Not Synced</string>
 
     <string-array name="nav_list_titles">
         <item>Overview</item>
@@ -560,5 +561,4 @@
 
     <string name="external_output_amount">%1$s DCR (external)</string>
     <string name="external_output_account">%1$s DCR (%2$s)</string>
-    <string name="field_cannot_be_empty">Field cannot be empty</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,4 +560,5 @@
 
     <string name="external_output_amount">%1$s DCR (external)</string>
     <string name="external_output_account">%1$s DCR (%2$s)</string>
+    <string name="field_cannot_be_empty">Field cannot be empty</string>
 </resources>


### PR DESCRIPTION
1. Changed how error is displayed if a wrong passphrase is entered in AddAccount screen.

Before: Toast message
<img src="https://user-images.githubusercontent.com/13119278/53450661-29b98f00-3a1d-11e9-9dd5-28b65ebeaab8.jpg" height="500">

After: TextView error
<img src="https://user-images.githubusercontent.com/13119278/53450699-448c0380-3a1d-11e9-8aac-9e6c9d470702.jpg" height="500">

2.Changed how error is displayed if text-field is left empty on the screen to 'Enter Current Password' when a user is about to change spending or startup password.

Before: Snackbar message
<img src="https://user-images.githubusercontent.com/13119278/53451105-4efacd00-3a1e-11e9-84db-29ae56676352.jpg" height="500">

After: TextView error
<img src="https://user-images.githubusercontent.com/13119278/53451168-78b3f400-3a1e-11e9-92a0-c5c953e503b7.jpg" height="500">

