### PR TITLE
Stop address discovery thread during rescan

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -941,6 +941,10 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
             walletData.syncEndPoint = walletData.wallet.getBestBlock();
         }
 
+        if (accountDiscoveryProgress != null && accountDiscoveryProgress.isAlive()) {
+            accountDiscoveryProgress.interrupt();
+        }
+
         switch (state) {
             case Dcrlibwallet.START:
                 setConnectionStatus(R.string.scanning_blocks);


### PR DESCRIPTION
Closes #320 
This fixes a glitch that can occur if `DiscoverAddressesFinished` doesn't get called by dcrlibwallet.
A likely cause is having a peer dropped around the time address discovery completes. 