### PR TITLE
overview: resume sync immediately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,4 @@
 /build
 /captures
 .externalNativeBuild
-pkg/pkg
-pkg/bin
-pkg/src/mobilewallet/vendor
+app/libs/dcrlibwallet.aar

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -82,7 +82,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
         transactionAdapter = TransactionAdapter(transactionList, context!!)
         iv_sync_indicator.setBackgroundResource(R.drawable.sync_animation)
 
-        if (!walletData!!.wallet.isSyncing) {
+        if (walletData!!.wallet.isSyncing) {
             iv_sync_indicator.post {
                 val syncAnimation = iv_sync_indicator.background as AnimationDrawable
                 syncAnimation.start()
@@ -91,7 +91,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
             pb_sync_progress.progress = 0
             overview_sync_layout.visibility = View.VISIBLE
             tv_synchronizing.setText(R.string.starting_synchronization)
-
+            walletData!!.wallet.publishLastSyncProgress()
         } else {
             getBalance()
             iv_sync_indicator.visibility = View.GONE

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -91,7 +91,6 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
             pb_sync_progress.progress = 0
             overview_sync_layout.visibility = View.VISIBLE
             tv_synchronizing.setText(R.string.starting_synchronization)
-            walletData!!.wallet.publishLastSyncProgress()
         } else {
             getBalance()
             iv_sync_indicator.visibility = View.GONE


### PR DESCRIPTION
This fix makes use of dcrlibwallet function publishLastSyncProgress() to make dcrlibwallet resend the last sync progress and that helps the overview page to display the sync estimate immediately instead of waiting till the next progress report.