### PR TITLE
wallet: update arguments passed to getTransactions, shutdown, and cancelSync wallet methods

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -531,7 +531,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
         stopService(syncIntent);
 
         if (walletData.wallet != null) {
-            walletData.wallet.shutdown(true); // Exit should probably be done here in android
+            walletData.wallet.shutdown(); // Exit should probably be done here in android
         }
 
         finish();
@@ -790,7 +790,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.tv_connection_status:
-                walletData.wallet.cancelSync(false);
+                walletData.wallet.cancelSync();
                 Toast.makeText(this, R.string.re_establishing_connection, Toast.LENGTH_SHORT).show();
                 checkWifiSync();
                 break;

--- a/app/src/main/java/com/dcrandroid/activities/SettingsActivity.java
+++ b/app/src/main/java/com/dcrandroid/activities/SettingsActivity.java
@@ -394,10 +394,10 @@ public class SettingsActivity extends AppCompatActivity {
                                 NetworkInfo networkInfo = connectionManager.getActiveNetworkInfo();
                                 if (networkInfo != null && networkInfo.isConnected()) {
                                     if (networkInfo.getType() != ConnectivityManager.TYPE_WIFI) {
-                                        wallet.cancelSync(false);
+                                        wallet.cancelSync();
                                     }
                                 } else {
-                                    wallet.cancelSync(false);
+                                    wallet.cancelSync();
                                 }
                             }
                         }

--- a/app/src/main/java/com/dcrandroid/activities/SplashScreen.java
+++ b/app/src/main/java/com/dcrandroid/activities/SplashScreen.java
@@ -117,7 +117,7 @@ public class SplashScreen extends AppCompatActivity {
         walletData = WalletData.getInstance();
 
         if (walletData.wallet != null) {
-            walletData.wallet.shutdown(false);
+            walletData.wallet.shutdown();
         }
 
         String homeDir = getFilesDir() + "/wallet";

--- a/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
@@ -28,7 +28,7 @@ import com.dcrandroid.data.Constants
 import com.dcrandroid.data.Transaction
 import com.dcrandroid.util.*
 import com.google.gson.GsonBuilder
-import dcrlibwallet.Dcrlibwallet.TxFilterAll
+import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.content_history.*
 import java.util.*
 
@@ -172,7 +172,7 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         object : Thread() {
             override fun run() {
                 try {
-                    val jsonResult = walletData!!.wallet.getTransactions(0, TxFilterAll)
+                    val jsonResult = walletData!!.wallet.getTransactions(0, Dcrlibwallet.TxFilterAll)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()

--- a/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
@@ -171,7 +171,7 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         object : Thread() {
             override fun run() {
                 try {
-                    val jsonResult = walletData!!.wallet.getTransactions(0)
+                    val jsonResult = walletData!!.wallet.getTransactions(0, 0)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()

--- a/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
@@ -28,6 +28,7 @@ import com.dcrandroid.data.Constants
 import com.dcrandroid.data.Transaction
 import com.dcrandroid.util.*
 import com.google.gson.GsonBuilder
+import dcrlibwallet.Dcrlibwallet.TxFilterAll
 import kotlinx.android.synthetic.main.content_history.*
 import java.util.*
 
@@ -171,7 +172,7 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         object : Thread() {
             override fun run() {
                 try {
-                    val jsonResult = walletData!!.wallet.getTransactions(0, 0)
+                    val jsonResult = walletData!!.wallet.getTransactions(0, TxFilterAll)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -35,6 +35,7 @@ import com.dcrandroid.data.Transaction
 import com.dcrandroid.util.*
 import com.google.gson.GsonBuilder
 import dcrlibwallet.*
+import dcrlibwallet.Dcrlibwallet.TxFilterAll
 import kotlinx.android.synthetic.main.content_overview.*
 import kotlinx.android.synthetic.main.overview_sync_layout.*
 import java.math.BigDecimal
@@ -284,7 +285,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
             override fun run() {
                 try {
 
-                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems(), 0)
+                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems(), TxFilterAll)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -35,7 +35,7 @@ import com.dcrandroid.data.Transaction
 import com.dcrandroid.util.*
 import com.google.gson.GsonBuilder
 import dcrlibwallet.*
-import dcrlibwallet.Dcrlibwallet.TxFilterAll
+import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.content_overview.*
 import kotlinx.android.synthetic.main.overview_sync_layout.*
 import java.math.BigDecimal
@@ -285,7 +285,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
             override fun run() {
                 try {
 
-                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems(), TxFilterAll)
+                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems(), Dcrlibwallet.TxFilterAll)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -284,7 +284,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
             override fun run() {
                 try {
 
-                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems())
+                    val jsonResult = walletData!!.wallet.getTransactions(getMaxDisplayItems(), 0)
 
                     val gson = GsonBuilder().registerTypeHierarchyAdapter(ArrayList::class.java, Deserializer.TransactionDeserializer())
                             .create()


### PR DESCRIPTION
* Update the number of arguments passed to getTranscations wallet method to reflect changes in dcrwallet library and fix failing build

* Remove the boolean argument passed to shutdown wallet method to reflect changes in dcrwallet library and fix failing build

* Remove the boolean argument passed to cancelSync wallet method to reflect changes in dcrwallet library and fix failing build