### PR TITLE
Implement restartSpvSync and restartRpcSync wallet methods

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -892,6 +892,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     @Override
     public void onSyncCanceled(boolean willRestart) {
         if (!willRestart) {
+            // clear sync layout if sync is not going to restart.
             walletData.synced = false;
             walletData.syncing = false;
 

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -565,6 +565,7 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
         if (context == null) {
             return
         }
+        // clear sync layout if sync is not going to restart.
         if (!willRestart)
             hideSyncLayout()
     }

--- a/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/OverviewFragment.kt
@@ -35,7 +35,6 @@ import com.dcrandroid.data.Transaction
 import com.dcrandroid.util.*
 import com.google.gson.GsonBuilder
 import dcrlibwallet.*
-import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.content_overview.*
 import kotlinx.android.synthetic.main.overview_sync_layout.*
 import java.math.BigDecimal
@@ -562,24 +561,25 @@ class OverviewFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, SyncP
         }
     }
 
-    override fun onSyncCanceled() {
-        if(context == null){
+    override fun onSyncCanceled(willRestart: Boolean) {
+        if (context == null) {
             return
         }
-        hideSyncLayout()
+        if (!willRestart)
+            hideSyncLayout()
     }
 
     override fun onPeerConnectedOrDisconnected(numberOfConnectedPeers: Int) {}
 
     override fun onSyncCompleted() {
-        if(context == null){
+        if (context == null) {
             return
         }
         hideSyncLayout()
     }
 
     override fun onSyncEndedWithError(err: java.lang.Exception?) {
-        if(context == null){
+        if (context == null) {
             return
         }
         err!!.printStackTrace()

--- a/app/src/main/java/com/dcrandroid/service/SyncService.kt
+++ b/app/src/main/java/com/dcrandroid/service/SyncService.kt
@@ -146,6 +146,7 @@ class SyncService : Service(), SyncProgressListener {
             println("Sync Restarting")
             return
         }
+        // remove sync notification if sync is not going to restart.
         println("Sync Canceled, destroying service")
         stopForeground(true)
         stopSelf()

--- a/app/src/main/java/com/dcrandroid/service/SyncService.kt
+++ b/app/src/main/java/com/dcrandroid/service/SyncService.kt
@@ -72,10 +72,15 @@ class SyncService : Service(), SyncProgressListener {
         wallet!!.removeSyncProgressListener(TAG)
         wallet!!.addSyncProgressListener(this, TAG)
 
-        val peerAddresses = preferenceUtil!!.get(Constants.PEER_IP)
-
-        Log.d(TAG, "Starting SPV Sync")
-        wallet!!.spvSync(peerAddresses)
+        if (Integer.parseInt(preferenceUtil!!.get(Constants.NETWORK_MODES, "0")) == 0) {
+            val peerAddresses = preferenceUtil!!.get(Constants.PEER_IP)
+            Log.d(TAG, "Starting SPV Sync")
+            wallet!!.spvSync(peerAddresses)
+        } else {
+            val remoteNodeAddress = preferenceUtil!!.get(Constants.REMOTE_NODE_ADDRESS)
+            Log.d(TAG, "Starting RPC Sync")
+            wallet!!.rpcSync(remoteNodeAddress, "dcrwallet", "dcrwallet", Utils.getRemoteCertificate(this).toByteArray())
+        }
 
         return super.onStartCommand(intent, flags, startId)
     }
@@ -136,7 +141,11 @@ class SyncService : Service(), SyncProgressListener {
         err.printStackTrace()
     }
 
-    override fun onSyncCanceled() {
+    override fun onSyncCanceled(willRestart: Boolean) {
+        if(willRestart){
+            println("Sync Restarting")
+            return
+        }
         println("Sync Canceled, destroying service")
         stopForeground(true)
         stopSelf()


### PR DESCRIPTION
This does a clean restart of sync without messing up the displayed estimates. This also fixes a bug that caused restarting sync to return a "sync_in_progress" error.