### PR TITLE
disable new block notification during sync

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -707,7 +707,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     public void onBlockAttached(int height, long timestamp) {
         this.bestBlock = height;
         this.bestBlockTimestamp = timestamp / 1000000000;
-        if (util.getBoolean(Constants.NEW_BLOCK_NOTIFICATION, false)) {
+        if (util.getBoolean(Constants.NEW_BLOCK_NOTIFICATION, false) && !walletData.wallet.isSyncing()) {
             alertSound.play(blockNotificationSound, 1, 1, 1, 0, 1);
         }
         if (!walletData.syncing) {


### PR DESCRIPTION
This would help in avoid an issue where a bunch of blocks come in at once and would cause a lot of beeps.