### PR TITLE
overview: hide sync layout if user choose not to sync

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -375,6 +375,11 @@ public class MainActivity extends BaseActivity implements TransactionListener,
                 sendBroadcast(new Intent(Constants.SYNCED));
                 setConnectionStatus(R.string.connect_to_wifi);
                 connectionStatus.setBackgroundColor(getResources().getColor(android.R.color.holo_red_light));
+
+                if(currentFragment instanceof OverviewFragment){
+                    OverviewFragment overviewFragment = (OverviewFragment) currentFragment;
+                    overviewFragment.onSyncCanceled(false);
+                }
             }
         });
 

--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -362,9 +362,16 @@ public class MainActivity extends BaseActivity implements TransactionListener,
                 .setPositiveButton(new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
+
                         startSyncing();
+
                         WiFiSyncDialog syncDialog = (WiFiSyncDialog) dialog;
                         util.setBoolean(Constants.WIFI_SYNC, syncDialog.getChecked());
+
+                        if(currentFragment instanceof OverviewFragment){
+                            OverviewFragment overviewFragment = (OverviewFragment) currentFragment;
+                            overviewFragment.setupSyncLayout();
+                        }
                     }
                 });
 

--- a/app/src/main/java/com/dcrandroid/adapter/AccountSpinnerAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/AccountSpinnerAdapter.kt
@@ -17,7 +17,7 @@ import com.dcrandroid.data.Account
 import com.dcrandroid.util.CoinFormat
 import dcrlibwallet.Dcrlibwallet
 
-class AccountSpinnerAdapter(val accounts: ArrayList<Account>, val inflater: LayoutInflater) : BaseAdapter(), SpinnerAdapter {
+class AccountSpinnerAdapter(val accounts: List<Account>, val inflater: LayoutInflater) : BaseAdapter(), SpinnerAdapter {
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
         var vi = convertView

--- a/app/src/main/java/com/dcrandroid/data/Account.java
+++ b/app/src/main/java/com/dcrandroid/data/Account.java
@@ -25,10 +25,12 @@ public class Account implements Serializable {
     private int accountNumber, externalKeyCount, internalKeyCount, importedKeyCount;
 
     public static ArrayList<Account> parse(String json) throws JSONException {
+
         JSONObject obj = new JSONObject(json);
         JSONArray acc = obj.getJSONArray("Acc");
         ArrayList<Account> items = new ArrayList<>();
         for (int i = 0; i < acc.length(); i++) {
+
             final JSONObject accJSONObject = acc.getJSONObject(i);
             Account account = new Account();
             account.setAccountNumber(accJSONObject.getInt(Constants.NUMBER));
@@ -37,6 +39,7 @@ public class Account implements Serializable {
             account.setInternalKeyCount(accJSONObject.getInt(Constants.INTERNAL_KEY_COUNT));
             account.setImportedKeyCount(accJSONObject.getInt(Constants.IMPORTED_KEY_COUNT));
             JSONObject balanceObj = accJSONObject.getJSONObject(Constants.BALANCE);
+
             Balance balance = new Balance();
             balance.setTotal(balanceObj.getLong(Constants.TOTAL));
             balance.setSpendable(balanceObj.getLong(Constants.SPENDABLE));

--- a/app/src/main/java/com/dcrandroid/extensions/LibWallet.kt
+++ b/app/src/main/java/com/dcrandroid/extensions/LibWallet.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018-2019 The Decred developers
+ * Use of this source code is governed by an ISC
+ * license that can be found in the LICENSE file.
+ */
+
+package com.dcrandroid.extensions
+
+import android.content.Context
+import com.dcrandroid.data.Account
+import com.dcrandroid.data.Constants
+import com.dcrandroid.util.PreferenceUtil
+import dcrlibwallet.LibWallet
+
+fun LibWallet.walletAccounts(requiredConfirmations: Int) : ArrayList<Account>{
+    return Account.parse(this.getAccounts(requiredConfirmations))
+}
+
+fun LibWallet.visibleWalletAccounts(requiredConfirmations: Int, context: Context) : List<Account>{
+    val util = PreferenceUtil(context)
+    return this.walletAccounts(requiredConfirmations).filter { !util.getBoolean(Constants.HIDE_WALLET + it.accountNumber) }
+}
+
+fun LibWallet.totalWalletBalance(requiredConfirmations: Int, context: Context): Long{
+    val visibleAccounts = this.visibleWalletAccounts(requiredConfirmations, context)
+
+   return visibleAccounts.map { it.balance.total }.reduce { sum, element -> sum + element}
+}

--- a/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/HistoryFragment.kt
@@ -241,9 +241,9 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
                                     if (hashIndex == -1) {
                                         // All transactions in this list is new
-                                        transactionList.animateNewItems(0, transactionList.size - 1)
+                                        transactionList.map { it.animate = true }
                                     } else if (hashIndex != 0) {
-                                        transactionList.animateNewItems(0, hashIndex - 1)
+                                        transactionList.mapIndexed { index, it -> if(index < hashIndex) it.animate = true }
                                     }
                                 }
 
@@ -286,9 +286,11 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
             // Transaction is a duplicate
             return
         }
+
         if (transaction.height > 0) {
             latestTransactionHeight = transaction.height + 1
         }
+
         transactionList.add(0, transaction)
         println("New transaction info ${transaction.hash}")
         util!!.set(Constants.RECENT_TRANSACTION_HASH, transaction.hash)
@@ -351,13 +353,6 @@ class HistoryFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     prepareHistoryData()
                 }
             }
-        }
-    }
-
-    private fun ArrayList<Transaction>.animateNewItems(start: Int, count: Int) {
-        for (i: Int in start..count) {
-            val item = this[i]
-            item.animate = true
         }
     }
 }

--- a/app/src/main/java/com/dcrandroid/fragments/SendFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/SendFragment.kt
@@ -31,6 +31,7 @@ import com.dcrandroid.data.Account
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.ConfirmTransactionDialog
 import com.dcrandroid.dialog.InfoDialog
+import com.dcrandroid.extensions.visibleWalletAccounts
 import com.dcrandroid.util.*
 import dcrlibwallet.Dcrlibwallet
 import dcrlibwallet.LibWallet
@@ -56,7 +57,7 @@ class SendFragment : Fragment(), AdapterView.OnItemSelectedListener, GetExchange
     private var exchangeRate: Double = -1.0
     private var exchangeDecimal: BigDecimal? = null
     private val formatter: DecimalFormat = NumberFormat.getNumberInstance(Locale.ENGLISH) as DecimalFormat
-    private var accounts: ArrayList<Account> = ArrayList()
+    private var accounts: List<Account> = ArrayList()
     private var dataAdapter: AccountSpinnerAdapter? = null
     private var util: PreferenceUtil? = null
     private var pd: ProgressDialog? = null
@@ -293,8 +294,8 @@ class SendFragment : Fragment(), AdapterView.OnItemSelectedListener, GetExchange
     override fun onNothingSelected(parent: AdapterView<*>?) {}
 
     private fun prepareAccounts() {
-        accounts = Account.parse(wallet.getAccounts(requiredConfirmations))
-        accounts = ArrayList(accounts.filter { it.accountNumber != Int.MAX_VALUE }) // Filter out imported account
+        accounts = wallet.visibleWalletAccounts(requiredConfirmations, context!!)
+        accounts = accounts.filter { it.accountNumber != Int.MAX_VALUE }.toList() // Filter out imported account
 
         if (dataAdapter != null) {
             requireActivity().runOnUiThread {

--- a/app/src/main/res/layout/content_overview.xml
+++ b/app/src/main/res/layout/content_overview.xml
@@ -47,14 +47,8 @@
                     android:layout_height="wrap_content"
                     android:textColor="@color/darkBlueTextColor"
                     android:textSize="24sp"
-                    android:visibility="gone"
                     app:fontFamily="@font/inconsolata_regular_family"
                     tools:visibility="visible" />
-
-                <ImageView
-                    android:id="@+id/iv_sync_indicator"
-                    android:layout_width="50dp"
-                    android:layout_height="50dp" />
             </LinearLayout>
 
             <TextView


### PR DESCRIPTION
Choosing 'No' on the wifi dialog does not update the overview page which causes the "Starting synchronization" label to be shown even when sync isn't going to start.