### PR TITLE
Feature/Defer wallet creation/restore

### DIFF
--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -825,9 +825,9 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     public void onClick(View v) {
         switch (v.getId()) {
             case R.id.tv_connection_status:
-                if (Integer.parseInt(util.get(Constants.NETWORK_MODES, "0")) == 0) {
+                if (Integer.parseInt(preferenceUtil.get(Constants.NETWORK_MODES, "0")) == 0) {
                     setConnectionStatus(R.string.connecting_to_peers);
-                    String peerAddresses = util.get(Constants.PEER_IP);
+                    String peerAddresses = preferenceUtil.get(Constants.PEER_IP);
                     try {
                         walletData.wallet.restartSpvSync(peerAddresses);
                     } catch (Exception e) {
@@ -835,7 +835,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
                     }
                 } else {
                     setConnectionStatus(R.string.connecting_to_rpc_server);
-                    String remoteNodeAddress = util.get(Constants.REMOTE_NODE_ADDRESS);
+                    String remoteNodeAddress = preferenceUtil.get(Constants.REMOTE_NODE_ADDRESS);
                     try {
                         walletData.wallet.restartRpcSync(remoteNodeAddress, "dcrwallet", "dcrwallet", Utils.getRemoteCertificate(this).getBytes());
                     } catch (Exception e) {

--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -260,15 +260,11 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
             alertSound = new SoundPool(3, AudioManager.STREAM_NOTIFICATION, 0);
         }
 
-        blockNotificationSound = alertSound.load(MainActivity.this, R.raw.beep, 1);
+        setSoundNotification();
 
         walletData.wallet.transactionNotification(this);
-        try {
-            walletData.wallet.removeSyncProgressListener(TAG);
-            walletData.wallet.addSyncProgressListener(this, TAG);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+
+        setSyncSyncProgressListener();
 
         displayBalance();
 
@@ -306,6 +302,30 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
             if (pageID != 0)
                 displayOverview();
         }
+    }
+
+    private void setSyncSyncProgressListener() {
+        try {
+            walletData.wallet.removeSyncProgressListener(TAG);
+            walletData.wallet.addSyncProgressListener(this, TAG);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void setSoundNotification() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            SoundPool.Builder builder = new SoundPool.Builder().setMaxStreams(3);
+            AudioAttributes attributes = new AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION_EVENT)
+                    .setLegacyStreamType(AudioManager.STREAM_NOTIFICATION).build();
+            builder.setAudioAttributes(attributes);
+            alertSound = builder.build();
+        } else {
+            alertSound = new SoundPool(3, AudioManager.STREAM_NOTIFICATION, 0);
+        }
+
+        blockNotificationSound = alertSound.load(MainActivity.this, R.raw.beep, 1);
     }
 
     public void displayBalance() {

--- a/app/src/main/java/com/dcrandroid/MainActivity.java
+++ b/app/src/main/java/com/dcrandroid/MainActivity.java
@@ -116,7 +116,7 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     private boolean scanning = false, isForeground;
 
     private final String TAG = "MainActivity";
-    private boolean noWalletCreated;
+    private boolean noWalletCreated, isSyncing = false;
 
     @Override
     public void onTrimMemory(int level) {
@@ -253,22 +253,9 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
 
         if (noWalletCreated) {
             displayCreateWalletPrompt();
-            return;
+        } else {
+            startSync();
         }
-
-        displayOverview();
-
-        setSoundNotification();
-
-        walletData.wallet.transactionNotification(this);
-
-        setSyncSyncProgressListener();
-
-        displayBalance();
-
-        checkWifiSync();
-
-        startBlockUpdate();
     }
 
     @Override
@@ -281,6 +268,11 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
     protected void onResume() {
         super.onResume();
         isForeground = true;
+        noWalletCreated = preferenceUtil.getBoolean(Constants.NO_WALLET_CREATED);
+
+        if (!noWalletCreated && !isSyncing) {
+            startSync();
+        }
 
         if (broadcastIntent != null)
             handler.postDelayed(new Runnable() {
@@ -309,6 +301,24 @@ public class MainActivity extends AppCompatActivity implements TransactionListen
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void startSync() {
+        isSyncing = true; // to avoid starting sync again
+
+        displayOverview();
+
+        setSoundNotification();
+
+        walletData.wallet.transactionNotification(this);
+
+        setSyncSyncProgressListener();
+
+        displayBalance();
+
+        checkWifiSync();
+
+        startBlockUpdate();
     }
 
     private void setSoundNotification() {

--- a/app/src/main/java/com/dcrandroid/data/Constants.java
+++ b/app/src/main/java/com/dcrandroid/data/Constants.java
@@ -112,7 +112,8 @@ public class Constants {
             SYNC_STATE_START = "start",
             SYNC_STATE_PROGRESS = "progress",
             SYNC_STATE_FINISH = "finish",
-            RECENT_TRANSACTION_HASH = "recent_transaction_hash";
+            RECENT_TRANSACTION_HASH = "recent_transaction_hash",
+            NO_WALLET_CREATED = "noWallet";
 
     public static final int TRANSACTION_SUMMARY_ID = 5552478, REQUIRED_CONFIRMATIONS = 2;
 

--- a/app/src/main/java/com/dcrandroid/fragments/PasswordFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/PasswordFragment.kt
@@ -17,7 +17,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import com.dcrandroid.MainActivity
 import com.dcrandroid.R
@@ -68,7 +67,7 @@ class PasswordFragment : Fragment(), View.OnKeyListener {
     }
 
     private fun createWallet(password: String) {
-        if(password.isEmpty()){
+        if (password.isEmpty()) {
             Snackbar.make(view!!, R.string.empty_password, Snackbar.LENGTH_SHORT).show()
             return
         }
@@ -82,13 +81,14 @@ class PasswordFragment : Fragment(), View.OnKeyListener {
                 wallet.unlockWallet(password.toByteArray())
                 val util = PreferenceUtil(this@PasswordFragment.context!!)
                 util.set(Constants.SPENDING_PASSPHRASE_TYPE, Constants.PASSWORD)
+                util.setBoolean(Constants.NO_WALLET_CREATED, false);
                 activity!!.runOnUiThread {
                     pd!!.dismiss()
                     val i = Intent(this@PasswordFragment.context, MainActivity::class.java)
                     i.putExtra(Constants.PASSPHRASE, password)
                     startActivity(i)
                     //Finish all the activities before this
-                    ActivityCompat.finishAffinity(this@PasswordFragment.activity!!)
+                    //ActivityCompat.finishAffinity(this@PasswordFragment.activity!!)
                 }
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/src/main/java/com/dcrandroid/fragments/PinFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/PinFragment.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import com.dcrandroid.MainActivity
 import com.dcrandroid.R
@@ -95,13 +94,14 @@ class PinFragment : Fragment(), KeyPad.KeyPadListener {
                 wallet.unlockWallet(passCode!!.toByteArray())
                 val util = PreferenceUtil(this@PinFragment.context!!)
                 util.set(Constants.SPENDING_PASSPHRASE_TYPE, Constants.PIN)
+                util.setBoolean(Constants.NO_WALLET_CREATED, false);
                 activity!!.runOnUiThread {
                     pd!!.dismiss()
                     val i = Intent(this@PinFragment.context, MainActivity::class.java)
                     i.putExtra(Constants.PASSPHRASE, passCode)
                     startActivity(i)
                     //Finish all the activities before this
-                    ActivityCompat.finishAffinity(this@PinFragment.activity!!)
+                    //ActivityCompat.finishAffinity(this@PinFragment.activity!!)
                 }
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/app/src/main/java/com/dcrandroid/fragments/SetUpWalletPromptFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/SetUpWalletPromptFragment.kt
@@ -1,0 +1,30 @@
+package com.dcrandroid.fragments
+
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.dcrandroid.R
+import com.dcrandroid.activities.SetupWalletActivity
+import kotlinx.android.synthetic.main.fragment_setup_wallet_prompt.*
+
+class SetUpWalletPromptFragment : Fragment() {
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        tv_get_started.setOnClickListener { navigateToCreateWalletPage() }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_setup_wallet_prompt, container, false)
+    }
+
+    private fun navigateToCreateWalletPage() {
+        val intent = Intent(activity, SetupWalletActivity::class.java)
+        startActivity(intent)
+    }
+}

--- a/app/src/main/res/layout/fragment_setup_wallet_prompt.xml
+++ b/app/src/main/res/layout/fragment_setup_wallet_prompt.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tv_create_wallet_prompt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:lineSpacingExtra="3sp"
+        android:text="@string/create_or_recover_your_wallet_prompt"
+        android:textSize="18sp" />
+
+    <TextView
+        android:id="@+id/tv_get_started"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/click_here_to_get_started"
+        android:textAlignment="center"
+        android:textSize="16sp"
+        android:textColor="@color/blueGraySecondTextColor" />
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,6 +228,8 @@
     <string name="invalid_current_password">Current password entered was not valid.</string>
     <string name="creating_wallet">Creating wallet…</string>
     <string name="failed_to_open_wallet">Failed to open wallet</string>
+    <string name="create_or_recover_your_wallet_prompt">You need to create or recover your wallet \n so that you can start managing your decred.</string>
+    <string name="click_here_to_get_started"><u>Click Here To get Started</u></string>
     <!--/Wallet-->
 
     <!--Transaction-->


### PR DESCRIPTION
#### This PR delays the setup wallet process on the first installation.
User will go straight to the wallet and be able to start using it. On the overview page will be an alert notification that tells them they still need to save their wallet seed. 
They can click it when ready, and will at that point be shown their words and asked to verify. Once it is confirmed verified, the alert on the overview page will no longer show.
#### How to manually test.
- Do a fresh installation of the app. You should be taken straight to the overview page which a prompt message for creating the wallet.
- Tap on it and you should go through the wallet creation or restore process and after its done the prompt should no longer display.
#### Screenshot
![Screenshot_20190630-185625](https://user-images.githubusercontent.com/4677105/60399158-308e1500-9b69-11e9-8839-4820958f14d9.png)
