### PR TITLE
Align views on send Fragment

### DIFF
--- a/app/src/main/res/layout/fragment_send.xml
+++ b/app/src/main/res/layout/fragment_send.xml
@@ -49,7 +49,7 @@
             android:paddingTop="5dp">
 
             <TextView
-                android:layout_width="55dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="end"
                 android:text="@string/from_colon"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.21'
 
     repositories {
         jcenter()
@@ -15,7 +15,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
This PR corrects the alignment of views on send fragment when the device text is set to large. See https://github.com/decred/dcrandroid/issues/305

Before:
![before_sending](https://user-images.githubusercontent.com/4796738/60456842-487d9b80-9c32-11e9-9f9b-e7e824033f5c.png)

After:
![send_screen_after](https://user-images.githubusercontent.com/4796738/60456854-5501f400-9c32-11e9-8d3f-6b893bc1fd2a.png)

