### PR TITLE
 verify seed: reveal next row when tapping seeds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,6 +58,12 @@
             android:launchMode="singleTask"
             android:theme="@style/LightTheme.NoActionBar" />
         <activity
+            android:name=".activities.VerifySeedActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:theme="@style/LightTheme.NoActionBar" />
+        <activity
             android:name=".activities.SetupWalletActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"

--- a/app/src/main/java/com/dcrandroid/activities/ConfirmSeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/ConfirmSeedActivity.kt
@@ -19,37 +19,28 @@ import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dcrandroid.R
-import com.dcrandroid.adapter.CreateWalletAdapter
 import com.dcrandroid.adapter.InputSeed
-import com.dcrandroid.adapter.MultiSeed
 import com.dcrandroid.adapter.RestoreWalletAdapter
 import com.dcrandroid.data.Constants
 import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.confirm_seed_page.*
-import java.util.*
-import kotlin.collections.ArrayList
-
 
 private const val CLICK_THRESHOLD = 300 //millisecond
 
-// TODO: Split this class into VerifySeedActivity  for old wallet and EnterSeedActivity for new wallet.
 class ConfirmSeedActivity : BaseActivity(), View.OnTouchListener {
 
-    private var restore: Boolean = false
     private var verifiedSeed: Boolean = false
+    private var lastConfirmClick: Long = 0
+    private var finalSeedsString = ""
+
     private var allSeeds = ArrayList<String>()
     private val seedsForInput = ArrayList<InputSeed>()
     private val confirmedSeedsArray = ArrayList<InputSeed>()
     private var sortedList = listOf<InputSeed>()
-    private val arrayOfRandomSeeds = ArrayList<InputSeed>()
-    private val arrayOfSeedLists = ArrayList<MultiSeed>()
-    private val shuffledSeeds = ArrayList<InputSeed>()
-    private var finalSeedsString = ""
-    private var lastConfirmClick: Long = 0
+
     private var handler: Handler? = null
-    private var currentSeedPosition = 0
+
     private lateinit var restoreWalletAdapter: RestoreWalletAdapter
-    private lateinit var createWalletAdapter: CreateWalletAdapter
     private lateinit var linearLayoutManager: LinearLayoutManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -67,25 +58,17 @@ class ConfirmSeedActivity : BaseActivity(), View.OnTouchListener {
     private fun prepareData() {
         val bundle = intent.extras
         val temp = arrayOfNulls<String>(33)
-        if (!bundle.isEmpty) {
+        if (bundle != null && !bundle.isEmpty) {
             val seed = bundle.getString(Constants.SEED)
-            restore = bundle.getBoolean(Constants.RESTORE)
             allSeeds = ArrayList(seed.split(" "))
-            if (restore) {
-                temp.forEachIndexed { number, _ ->
-                    seedsForInput.add(InputSeed(number, " "))
-                    initOldWalletAdapter()
-                }
-            } else {
-                tvHeader.text = getString(R.string.seed_phrase_verification)
-                tvHint.text = getString(R.string.please_confirm_your_seed_by_typing_and_tapping_each_word_accordingly)
-                headerTop.isFocusableInTouchMode = true
-                initNewWalletAdapter()
+            temp.forEachIndexed { number, _ ->
+                seedsForInput.add(InputSeed(number, " "))
+                initSeedAdapter()
             }
         }
     }
 
-    private fun initOldWalletAdapter() {
+    private fun initSeedAdapter() {
         restoreWalletAdapter = RestoreWalletAdapter(seedsForInput, allSeeds, applicationContext,
                 { savedSeed: InputSeed ->
                     confirmedSeedsArray.add(savedSeed)
@@ -118,81 +101,6 @@ class ConfirmSeedActivity : BaseActivity(), View.OnTouchListener {
             }
         })
         recyclerViewSeeds.adapter = restoreWalletAdapter
-    }
-
-    private fun initNewWalletAdapter() {
-        createWalletAdapter = CreateWalletAdapter(applicationContext, arrayOfSeedLists, { enteredSeeds: ArrayList<InputSeed> ->
-            confirmedSeedsArray.clear()
-            confirmedSeedsArray.addAll(enteredSeeds)
-            sortedList = confirmedSeedsArray.sortedWith(compareBy { it.number }).distinct()
-
-            if (sortedList.size < 33) {
-                tvError.visibility = View.VISIBLE
-                tvError.text = getString(R.string.notAllSeedsEntered)
-            }
-            val itemView = recyclerViewSeeds.findViewById<RelativeLayout>(R.id.rlButtons)
-            val itemHeight = itemView.measuredHeight
-            val maxAllowedHeight = nestedScrollView.getChildAt(0).bottom - (itemView.measuredHeight + itemView.measuredHeight / 2)
-
-            val currentHeight = (nestedScrollView.scrollY + nestedScrollView.height)
-            if (currentHeight > maxAllowedHeight) {
-                nestedScrollView.smoothScrollBy(0, itemHeight * 2)
-            }
-        }, { isAllEntered: Boolean ->
-            if (isAllEntered && sortedList.size == 33) {
-                handleSingleTap()
-            }
-        })
-        recyclerViewSeeds.adapter = createWalletAdapter
-        generateRandomSeeds()
-    }
-
-    private fun generateRandomSeeds() {
-        val firstRandom = (1..allSeeds.size).random()
-        val secondRandom = (1..allSeeds.size).random()
-        var currentItemPosition = 0
-        if (currentSeedPosition != 33) {
-            currentItemPosition = (currentSeedPosition)
-        }
-
-        if (firstRandom != secondRandom && firstRandom != currentItemPosition && secondRandom != currentItemPosition) {
-            for (item in allSeeds) {
-                when (item) {
-                    allSeeds[firstRandom] -> arrayOfRandomSeeds.add(InputSeed(firstRandom, item))
-                    allSeeds[secondRandom] -> arrayOfRandomSeeds.add(InputSeed(secondRandom, item))
-                    allSeeds[currentItemPosition] -> arrayOfRandomSeeds.add(InputSeed(currentItemPosition, item))
-                }
-            }
-            addSeedsToAdapter()
-        } else {
-            generateRandomSeeds()
-        }
-    }
-
-    private fun addSeedsToAdapter() {
-        shuffledSeeds.addAll(arrayOfRandomSeeds.shuffled().distinct())
-        if (shuffledSeeds.size == 3) {
-            when {
-                currentSeedPosition < 32 -> {
-                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
-                    createWalletAdapter.notifyDataSetChanged()
-                    currentSeedPosition++
-                    arrayOfRandomSeeds.clear()
-                    shuffledSeeds.clear()
-                    generateRandomSeeds()
-                }
-                currentSeedPosition == 32 -> {
-                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
-                    createWalletAdapter.notifyDataSetChanged()
-                    arrayOfRandomSeeds.clear()
-                    shuffledSeeds.clear()
-                }
-            }
-        } else {
-            arrayOfRandomSeeds.clear()
-            shuffledSeeds.clear()
-            generateRandomSeeds()
-        }
     }
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {
@@ -249,12 +157,7 @@ class ConfirmSeedActivity : BaseActivity(), View.OnTouchListener {
                 }
 
                 tvError.visibility = View.VISIBLE
-
-                if (restore) {
-                    tvError.text = getString(R.string.restore_wallet_incorrect_seed_input)
-                } else {
-                    tvError.text = getString(R.string.create_wallet_incorrect_seeds_input)
-                }
+                tvError.text = getString(R.string.restore_wallet_incorrect_seed_input)
             }
 
         } else if (sortedList.isNotEmpty() && (sortedList.size != 33)) {
@@ -263,6 +166,4 @@ class ConfirmSeedActivity : BaseActivity(), View.OnTouchListener {
             tvError.text = getString(R.string.theInputFieldIsEmpty)
         }
     }
-
-    private fun IntRange.random() = Random().nextInt((allSeeds.size + 1) - start)
 }

--- a/app/src/main/java/com/dcrandroid/activities/SaveSeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SaveSeedActivity.kt
@@ -45,7 +45,7 @@ class SaveSeedActivity : BaseActivity() {
             recyclerView.adapter = adp
 
             findViewById<Button>(R.id.save_seed_btn_continue).setOnClickListener {
-                val i = Intent(this@SaveSeedActivity, ConfirmSeedActivity::class.java)
+                val i = Intent(this@SaveSeedActivity, VerifySeedActivity::class.java)
                         .putExtra(Constants.SEED, seed)
                         .putExtra(Constants.RESTORE, false)
                 startActivity(i)

--- a/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2018-2019 The Decred developers
+ * Use of this source code is governed by an ISC
+ * license that can be found in the LICENSE file.
+ */
+
+package com.dcrandroid.activities
+
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.WindowManager
+import android.widget.RelativeLayout
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.dcrandroid.R
+import com.dcrandroid.adapter.CreateWalletAdapter
+import com.dcrandroid.adapter.InputSeed
+import com.dcrandroid.adapter.MultiSeed
+import com.dcrandroid.data.Constants
+import dcrlibwallet.Dcrlibwallet
+import kotlinx.android.synthetic.main.confirm_seed_page.*
+
+class VerifySeedActivity : BaseActivity() {
+
+    private var verifiedSeed: Boolean = false
+
+    private var finalSeedsString = ""
+
+    private var currentSeedPosition = 0
+
+    private var allSeeds = ArrayList<String>()
+    private val shuffledSeeds = ArrayList<InputSeed>()
+    private val arrayOfSeedLists = ArrayList<MultiSeed>()
+    private var sortedList = listOf<InputSeed>()
+    private val confirmedSeedsArray = ArrayList<InputSeed>()
+    private val arrayOfRandomSeeds = ArrayList<InputSeed>()
+
+    private lateinit var createWalletAdapter: CreateWalletAdapter
+    private lateinit var linearLayoutManager: LinearLayoutManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+
+        setContentView(R.layout.confirm_seed_page)
+        recyclerViewSeeds.isNestedScrollingEnabled = false
+        linearLayoutManager = LinearLayoutManager(this)
+        recyclerViewSeeds.layoutManager = linearLayoutManager
+        button_confirm_seed.setOnClickListener {
+            if (verifiedSeed) {
+                val intent = Intent(this, EncryptWallet::class.java)
+                intent.putExtra(Constants.SEED, finalSeedsString)
+                startActivity(intent)
+            }
+        }
+        prepareData()
+    }
+
+    private fun prepareData() {
+        val bundle = intent.extras
+        if (bundle != null && !bundle.isEmpty) {
+            val seed = bundle.getString(Constants.SEED)
+            if(seed != null) {
+                allSeeds = ArrayList(seed.split(" "))
+                tvHeader.text = getString(R.string.seed_phrase_verification)
+                tvHint.text = getString(R.string.please_confirm_your_seed_by_typing_and_tapping_each_word_accordingly)
+                headerTop.isFocusableInTouchMode = true
+                initSeedAdapter()
+            }
+        }
+    }
+
+    private fun initSeedAdapter() {
+        createWalletAdapter = CreateWalletAdapter(applicationContext, arrayOfSeedLists, { enteredSeeds: ArrayList<InputSeed> ->
+            confirmedSeedsArray.clear()
+            confirmedSeedsArray.addAll(enteredSeeds)
+            sortedList = confirmedSeedsArray.sortedWith(compareBy { it.number }).distinct()
+
+            if (sortedList.size < 33) {
+                tvError.visibility = View.VISIBLE
+                tvError.text = getString(R.string.notAllSeedsEntered)
+            }
+            val itemView = recyclerViewSeeds.findViewById<RelativeLayout>(R.id.rlButtons)
+            val itemHeight = itemView.measuredHeight
+            val maxAllowedHeight = nestedScrollView.getChildAt(0).bottom - (itemView.measuredHeight + itemView.measuredHeight / 2)
+
+            val currentHeight = (nestedScrollView.scrollY + nestedScrollView.height)
+            if (currentHeight > maxAllowedHeight) {
+                nestedScrollView.smoothScrollBy(0, itemHeight * 2)
+            }
+        }, { isAllEntered: Boolean ->
+            if (isAllEntered && sortedList.size == 33) {
+                handleSingleTap()
+            }
+        })
+        recyclerViewSeeds.adapter = createWalletAdapter
+        generateRandomSeeds()
+    }
+
+    private fun generateRandomSeeds() {
+        val firstRandom = (0 until allSeeds.size).random()
+        val secondRandom = (0 until allSeeds.size).random()
+        var currentItemPosition = 0
+        if (currentSeedPosition != 33) {
+            currentItemPosition = (currentSeedPosition)
+        }
+
+        if (firstRandom != secondRandom && firstRandom != currentItemPosition && secondRandom != currentItemPosition) {
+            for (item in allSeeds) {
+                when (item) {
+                    allSeeds[firstRandom] -> arrayOfRandomSeeds.add(InputSeed(firstRandom, item))
+                    allSeeds[secondRandom] -> arrayOfRandomSeeds.add(InputSeed(secondRandom, item))
+                    allSeeds[currentItemPosition] -> arrayOfRandomSeeds.add(InputSeed(currentItemPosition, item))
+                }
+            }
+            addSeedsToAdapter()
+        } else {
+            generateRandomSeeds()
+        }
+    }
+
+    private fun addSeedsToAdapter() {
+        shuffledSeeds.addAll(arrayOfRandomSeeds.shuffled().distinct())
+        if (shuffledSeeds.size == 3) {
+            when {
+                currentSeedPosition < 32 -> {
+                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
+                    createWalletAdapter.notifyDataSetChanged()
+                    currentSeedPosition++
+                    arrayOfRandomSeeds.clear()
+                    shuffledSeeds.clear()
+                    generateRandomSeeds()
+                }
+                currentSeedPosition == 32 -> {
+                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
+                    createWalletAdapter.notifyDataSetChanged()
+                    arrayOfRandomSeeds.clear()
+                    shuffledSeeds.clear()
+                }
+            }
+        } else {
+            arrayOfRandomSeeds.clear()
+            shuffledSeeds.clear()
+            generateRandomSeeds()
+        }
+    }
+
+    private fun handleSingleTap() {
+
+        if (sortedList.isNotEmpty() && (sortedList.size == 33)) {
+            finalSeedsString = sortedList.joinToString(" ", "", "", -1, "...") { it.phrase }
+            verifiedSeed = Dcrlibwallet.verifySeed(finalSeedsString)
+
+            if (verifiedSeed) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    button_confirm_seed.background = ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape3)
+                } else {
+                    button_confirm_seed.setBackgroundDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape3))
+                }
+
+                tvError.visibility = View.GONE
+
+            } else {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    button_confirm_seed.background = ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape2)
+                } else {
+                    button_confirm_seed.setBackgroundDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape2))
+                }
+
+                tvError.visibility = View.VISIBLE
+                tvError.text = getString(R.string.create_wallet_incorrect_seeds_input)
+            }
+
+        } else if (sortedList.isNotEmpty() && (sortedList.size != 33)) {
+            tvError.text = getString(R.string.notAllSeedsEntered)
+        } else {
+            tvError.text = getString(R.string.theInputFieldIsEmpty)
+        }
+    }
+}

--- a/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
@@ -7,54 +7,39 @@
 package com.dcrandroid.activities
 
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
-import android.view.View
 import android.view.WindowManager
-import android.widget.RelativeLayout
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dcrandroid.R
-import com.dcrandroid.adapter.CreateWalletAdapter
-import com.dcrandroid.adapter.InputSeed
-import com.dcrandroid.adapter.MultiSeed
+import com.dcrandroid.adapter.*
 import com.dcrandroid.data.Constants
+import com.dcrandroid.util.Utils
 import dcrlibwallet.Dcrlibwallet
-import kotlinx.android.synthetic.main.confirm_seed_page.*
+import kotlinx.android.synthetic.main.verify_seed_page.*
 
-class VerifySeedActivity : BaseActivity() {
+class VerifySeedActivity : BaseActivity(), SeedTapListener {
 
-    private var verifiedSeed: Boolean = false
-
-    private var finalSeedsString = ""
-
-    private var currentSeedPosition = 0
-
-    private var allSeeds = ArrayList<String>()
-    private val shuffledSeeds = ArrayList<InputSeed>()
-    private val arrayOfSeedLists = ArrayList<MultiSeed>()
-    private var sortedList = listOf<InputSeed>()
-    private val confirmedSeedsArray = ArrayList<InputSeed>()
-    private val arrayOfRandomSeeds = ArrayList<InputSeed>()
+    private var seeds = ArrayList<String>()
+    private lateinit var allSeeds: Array<String>
 
     private lateinit var createWalletAdapter: CreateWalletAdapter
     private lateinit var linearLayoutManager: LinearLayoutManager
+
+    private lateinit var footer: SeedPageFooter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
 
-        setContentView(R.layout.confirm_seed_page)
-        recyclerViewSeeds.isNestedScrollingEnabled = false
+        setContentView(R.layout.verify_seed_page)
+
         linearLayoutManager = LinearLayoutManager(this)
         recyclerViewSeeds.layoutManager = linearLayoutManager
-        button_confirm_seed.setOnClickListener {
-            if (verifiedSeed) {
-                val intent = Intent(this, EncryptWallet::class.java)
-                intent.putExtra(Constants.SEED, finalSeedsString)
-                startActivity(intent)
-            }
-        }
+
+        footer = SeedPageFooter(null, R.drawable.btn_shape2)
+
+        allSeeds = Utils.getWordList(this).split(" ").toTypedArray()
+
         prepareData()
     }
 
@@ -62,121 +47,103 @@ class VerifySeedActivity : BaseActivity() {
         val bundle = intent.extras
         if (bundle != null && !bundle.isEmpty) {
             val seed = bundle.getString(Constants.SEED)
-            if(seed != null) {
-                allSeeds = ArrayList(seed.split(" "))
-                tvHeader.text = getString(R.string.seed_phrase_verification)
-                tvHint.text = getString(R.string.please_confirm_your_seed_by_typing_and_tapping_each_word_accordingly)
-                headerTop.isFocusableInTouchMode = true
+            if (seed != null) {
+                seeds = ArrayList(seed.split(" "))
                 initSeedAdapter()
+                getMultiSeedList()
             }
         }
+    }
+
+    private fun getMultiSeedList(): ArrayList<MultiSeed> {
+        val multiSeedList = ArrayList<MultiSeed>()
+        for (seed in seeds) {
+            multiSeedList.add(getMultiSeed(allSeeds.indexOf(seed)))
+        }
+
+        return multiSeedList
+    }
+
+    private fun getMultiSeed(realSeedIndex: Int): MultiSeed {
+
+        val list = (0 until 33).toMutableList()
+        list.remove(realSeedIndex)
+
+        val firstRandom = list.random()
+        val firstInputSeed = InputSeed(firstRandom, allSeeds[firstRandom])
+        list.remove(firstRandom)
+
+        val secondRandom = list.random()
+        val secondInputSeed = InputSeed(secondRandom, allSeeds[secondRandom])
+
+        val realInputSeed = InputSeed(realSeedIndex, allSeeds[realSeedIndex])
+
+        val arr = ArrayList<InputSeed>()
+        arr.add(firstInputSeed)
+        arr.add(secondInputSeed)
+        arr.add(realInputSeed)
+
+        arr.shuffle()
+
+        return MultiSeed(arr[0], arr[1], arr[2])
     }
 
     private fun initSeedAdapter() {
-        createWalletAdapter = CreateWalletAdapter(applicationContext, arrayOfSeedLists, { enteredSeeds: ArrayList<InputSeed> ->
-            confirmedSeedsArray.clear()
-            confirmedSeedsArray.addAll(enteredSeeds)
-            sortedList = confirmedSeedsArray.sortedWith(compareBy { it.number }).distinct()
-
-            if (sortedList.size < 33) {
-                tvError.visibility = View.VISIBLE
-                tvError.text = getString(R.string.notAllSeedsEntered)
-            }
-            val itemView = recyclerViewSeeds.findViewById<RelativeLayout>(R.id.rlButtons)
-            val itemHeight = itemView.measuredHeight
-            val maxAllowedHeight = nestedScrollView.getChildAt(0).bottom - (itemView.measuredHeight + itemView.measuredHeight / 2)
-
-            val currentHeight = (nestedScrollView.scrollY + nestedScrollView.height)
-            if (currentHeight > maxAllowedHeight) {
-                nestedScrollView.smoothScrollBy(0, itemHeight * 2)
-            }
-        }, { isAllEntered: Boolean ->
-            if (isAllEntered && sortedList.size == 33) {
-                handleSingleTap()
-            }
-        })
+        val allSeedWords = getMultiSeedList()
+        createWalletAdapter = CreateWalletAdapter(this, allSeedWords, this, footer)
         recyclerViewSeeds.adapter = createWalletAdapter
-        generateRandomSeeds()
     }
 
-    private fun generateRandomSeeds() {
-        val firstRandom = (0 until allSeeds.size).random()
-        val secondRandom = (0 until allSeeds.size).random()
-        var currentItemPosition = 0
-        if (currentSeedPosition != 33) {
-            currentItemPosition = (currentSeedPosition)
-        }
-
-        if (firstRandom != secondRandom && firstRandom != currentItemPosition && secondRandom != currentItemPosition) {
-            for (item in allSeeds) {
-                when (item) {
-                    allSeeds[firstRandom] -> arrayOfRandomSeeds.add(InputSeed(firstRandom, item))
-                    allSeeds[secondRandom] -> arrayOfRandomSeeds.add(InputSeed(secondRandom, item))
-                    allSeeds[currentItemPosition] -> arrayOfRandomSeeds.add(InputSeed(currentItemPosition, item))
-                }
-            }
-            addSeedsToAdapter()
-        } else {
-            generateRandomSeeds()
-        }
+    private fun notAllSeedsEntered() {
+        footer.error = getString(R.string.notAllSeedsEntered)
+        // 34: last item on the last after adding up 1 header and 33 seed rows(using 0th index)
+        createWalletAdapter.notifyItemChanged(34)
     }
 
-    private fun addSeedsToAdapter() {
-        shuffledSeeds.addAll(arrayOfRandomSeeds.shuffled().distinct())
-        if (shuffledSeeds.size == 3) {
-            when {
-                currentSeedPosition < 32 -> {
-                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
-                    createWalletAdapter.notifyDataSetChanged()
-                    currentSeedPosition++
-                    arrayOfRandomSeeds.clear()
-                    shuffledSeeds.clear()
-                    generateRandomSeeds()
-                }
-                currentSeedPosition == 32 -> {
-                    arrayOfSeedLists.add(MultiSeed(shuffledSeeds[0], shuffledSeeds[1], shuffledSeeds[2]))
-                    createWalletAdapter.notifyDataSetChanged()
-                    arrayOfRandomSeeds.clear()
-                    shuffledSeeds.clear()
-                }
-            }
-        } else {
-            arrayOfRandomSeeds.clear()
-            shuffledSeeds.clear()
-            generateRandomSeeds()
+    override fun onConfirm(enteredSeeds: ArrayList<String>, emptySeed: Boolean) {
+
+        if (emptySeed) {
+            notAllSeedsEntered()
+            return
         }
+
+        val seedString = enteredSeeds.joinToString(" ", "", "", -1, "...")
+
+        if (Dcrlibwallet.verifySeed(seedString)) {
+            footer.buttonBackground = R.drawable.btn_shape3
+            footer.error = null
+
+            val intent = Intent(this, EncryptWallet::class.java)
+            intent.putExtra(Constants.SEED, seedString)
+            startActivity(intent)
+        } else {
+            footer.buttonBackground = R.drawable.btn_shape2
+            footer.error = getString(R.string.create_wallet_incorrect_seeds_input)
+        }
+
+
+        createWalletAdapter.notifyItemChanged(34)
     }
 
-    private fun handleSingleTap() {
+    override fun onSeedEntered(enteredSeeds: ArrayList<String>, emptySeed: Boolean, position: Int) {
 
-        if (sortedList.isNotEmpty() && (sortedList.size == 33)) {
-            finalSeedsString = sortedList.joinToString(" ", "", "", -1, "...") { it.phrase }
-            verifiedSeed = Dcrlibwallet.verifySeed(finalSeedsString)
+        linearLayoutManager.scrollToPosition(position + 2)
 
-            if (verifiedSeed) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                    button_confirm_seed.background = ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape3)
-                } else {
-                    button_confirm_seed.setBackgroundDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape3))
-                }
-
-                tvError.visibility = View.GONE
-
-            } else {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                    button_confirm_seed.background = ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape2)
-                } else {
-                    button_confirm_seed.setBackgroundDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.btn_shape2))
-                }
-
-                tvError.visibility = View.VISIBLE
-                tvError.text = getString(R.string.create_wallet_incorrect_seeds_input)
-            }
-
-        } else if (sortedList.isNotEmpty() && (sortedList.size != 33)) {
-            tvError.text = getString(R.string.notAllSeedsEntered)
-        } else {
-            tvError.text = getString(R.string.theInputFieldIsEmpty)
+        if (emptySeed) {
+            notAllSeedsEntered()
+            return
         }
+
+        val seedString = enteredSeeds.joinToString(" ", "", "", -1, "...")
+        if (Dcrlibwallet.verifySeed(seedString)) {
+            footer.buttonBackground = R.drawable.btn_shape3
+            footer.error = null
+        } else {
+            footer.buttonBackground = R.drawable.btn_shape2
+            footer.error = getString(R.string.create_wallet_incorrect_seeds_input)
+        }
+
+        // 34: last item on the last after adding up 1 header and 33 seed rows(using 0th index)
+        createWalletAdapter.notifyItemChanged(34)
     }
 }

--- a/app/src/main/java/com/dcrandroid/adapter/CreateWalletAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/CreateWalletAdapter.kt
@@ -11,25 +11,55 @@ import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.dcrandroid.R
 import kotlinx.android.synthetic.main.create_wallet_list_row.view.*
+import kotlinx.android.synthetic.main.verify_seed_footer.view.*
 
+private const val VIEW_TYPE_HEADER = 0
+private const val VIEW_TYPE_SEED = 1
+private const val VIEW_TYPE_FOOTER = 2
+
+class SeedPageFooter(var error: String?, @DrawableRes var buttonBackground: Int)
 data class MultiSeed(val firstSeed: InputSeed, val secondSeed: InputSeed, val thirdSeed: InputSeed)
 
-class CreateWalletAdapter(val context: Context, private val allListOfSeeds: ArrayList<MultiSeed>, val enteredSeeds: (ArrayList<InputSeed>) -> Unit,
-                          var isAllSeedsEntered: (Boolean) -> Unit) : RecyclerView.Adapter<CreateWalletAdapter.ViewHolder>() {
+interface SeedTapListener{
+    fun onConfirm(enteredSeeds: ArrayList<String>, emptySeed: Boolean)
+    fun onSeedEntered(enteredSeeds: ArrayList<String>, emptySeed: Boolean, position: Int)
+}
 
-    private val allEnteredSeeds = ArrayList<InputSeed>()
+class CreateWalletAdapter(val context: Context, private val allListOfSeeds: ArrayList<MultiSeed>, val listener: SeedTapListener, val footer: SeedPageFooter) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+    private val enteredSeeds = ArrayList<String>()
+    private var emptySeed: Boolean = true
+
+    init {
+        for(i in 0..32){
+            enteredSeeds.add(i, "")
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
-        return ViewHolder(layoutInflater.inflate(R.layout.create_wallet_list_row, parent, false))
+        return when(viewType){
+            VIEW_TYPE_HEADER -> {
+                HeaderViewHolder(layoutInflater.inflate(R.layout.verify_seed_header, parent, false))
+            }
+            VIEW_TYPE_SEED -> {
+                SeedViewHolder(layoutInflater.inflate(R.layout.create_wallet_list_row, parent, false))
+            }
+            else -> {
+                FooterViewHolder(layoutInflater.inflate(R.layout.verify_seed_footer, parent, false))
+            }
+        }
     }
 
     override fun getItemCount(): Int {
-        return allListOfSeeds.size
+        return allListOfSeeds.size + 2 // including header and footer
     }
 
     override fun getItemId(position: Int): Long {
@@ -38,59 +68,104 @@ class CreateWalletAdapter(val context: Context, private val allListOfSeeds: Arra
     }
 
     override fun getItemViewType(position: Int): Int {
-        return position
-    }
-
-    override fun onBindViewHolder(holder: CreateWalletAdapter.ViewHolder, position: Int) {
-        val currentMultiSeed = allListOfSeeds[position]
-        holder.firstSeed.text = currentMultiSeed.firstSeed.phrase
-        holder.secondSeed.text = currentMultiSeed.secondSeed.phrase
-        holder.thirdSeed.text = currentMultiSeed.thirdSeed.phrase
-        holder.multiSeedPosition.text = String.format("${context.getString(R.string.correctWordIs)}${holder.adapterPosition + 1}")
-
-        holder.firstSeed.setOnClickListener {
-            enableClick(holder.firstSeed)
-            disableClick(holder.secondSeed, holder.thirdSeed)
-            saveSeedToArray(InputSeed(position, holder.firstSeed.text.toString()))
-        }
-
-        holder.secondSeed.setOnClickListener {
-            enableClick(holder.secondSeed)
-            disableClick(holder.firstSeed, holder.thirdSeed)
-            saveSeedToArray(InputSeed(position, holder.secondSeed.text.toString()))
-        }
-
-        holder.thirdSeed.setOnClickListener {
-            enableClick(holder.thirdSeed)
-            disableClick(holder.secondSeed, holder.firstSeed)
-            saveSeedToArray(InputSeed(position, holder.thirdSeed.text.toString()))
+        return when (position){
+            0 -> VIEW_TYPE_HEADER
+            itemCount - 1 -> VIEW_TYPE_FOOTER
+            else -> VIEW_TYPE_SEED
         }
     }
 
-    private fun saveSeedToArray(seed: InputSeed) {
-        val toRemoveArray = ArrayList<InputSeed>()
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when(position){
+            0 -> {}
+            itemCount - 1 -> {
+                val footerHolder = holder as FooterViewHolder
 
-        if (allEnteredSeeds.isEmpty()) {
-            allEnteredSeeds.add(seed)
-        } else {
-            allEnteredSeeds.forEach {
-                if (it.number == seed.number) {
-                    toRemoveArray.add(it)
+                if(footer.error != null){
+                    footerHolder.error.visibility = View.VISIBLE
+                    footerHolder.error.text = footer.error
+                }else{
+                    footerHolder.error.visibility = View.GONE
+                }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    footerHolder.confirmButton.background = ContextCompat.getDrawable(context, footer.buttonBackground)
+                }else{
+                    footerHolder.confirmButton.setBackgroundDrawable(ContextCompat.getDrawable(context, footer.buttonBackground))
+                }
+
+                footerHolder.confirmButton.setOnClickListener {
+                    listener.onConfirm(enteredSeeds, emptySeed)
                 }
             }
-            allEnteredSeeds.add(seed)
-            allEnteredSeeds.removeAll(toRemoveArray)
+            else -> {
+                val seedHolder = holder as SeedViewHolder
+                seedHolder.multiSeedPosition.text = String.format("${context.getString(R.string.correctWordIs)}${seedHolder.adapterPosition}")
+                val seedIndex = seedHolder.adapterPosition - 1
+
+                val currentMultiSeed = allListOfSeeds[seedIndex]
+
+                seedHolder.firstSeed.text = currentMultiSeed.firstSeed.phrase
+                if(enteredSeeds[seedIndex] == currentMultiSeed.firstSeed.phrase){
+                    enableClick(seedHolder.firstSeed)
+                }else{
+                    disableClick(seedHolder.firstSeed)
+                }
+
+                seedHolder.secondSeed.text = currentMultiSeed.secondSeed.phrase
+                if(enteredSeeds[seedIndex] == currentMultiSeed.secondSeed.phrase){
+                    enableClick(seedHolder.secondSeed)
+                }else{
+                    disableClick(seedHolder.secondSeed)
+                }
+
+                seedHolder.thirdSeed.text = currentMultiSeed.thirdSeed.phrase
+                if(enteredSeeds[seedIndex] == currentMultiSeed.thirdSeed.phrase){
+                    enableClick(seedHolder.thirdSeed)
+                }else{
+                    disableClick(seedHolder.thirdSeed)
+                }
+
+                seedHolder.firstSeed.setOnClickListener {
+                    enableClick(seedHolder.firstSeed)
+                    disableClick(seedHolder.secondSeed, seedHolder.thirdSeed)
+                    saveSeedToArray(currentMultiSeed.firstSeed.phrase, seedIndex)
+                }
+
+                seedHolder.secondSeed.setOnClickListener {
+                    enableClick(seedHolder.secondSeed)
+                    disableClick(seedHolder.firstSeed, seedHolder.thirdSeed)
+                    saveSeedToArray(currentMultiSeed.secondSeed.phrase, seedIndex)
+                }
+
+                seedHolder.thirdSeed.setOnClickListener {
+                    enableClick(seedHolder.thirdSeed)
+                    disableClick(seedHolder.secondSeed, seedHolder.firstSeed)
+                    saveSeedToArray(currentMultiSeed.thirdSeed.phrase, seedIndex)
+                }
+            }
         }
-        enteredSeeds(allEnteredSeeds)
-        if (allEnteredSeeds.size == 33) {
-            isAllSeedsEntered(true)
-        } else {
-            isAllSeedsEntered(false)
+    }
+
+    private fun saveSeedToArray(seed: String, position: Int){
+        enteredSeeds[position] = seed
+
+        emptySeed = false
+        enteredSeeds.forEach {
+            if(it.isEmpty()){
+                emptySeed = true
+            }
         }
+
+        listener.onSeedEntered(enteredSeeds, emptySeed, position)
     }
 
     private fun enableClick(seed: View) {
         changeBackground(seed, true)
+    }
+
+    private fun disableClick(seed: View){
+        changeBackground(seed, false)
     }
 
     private fun disableClick(disableFirst: View, disableSecond: View) {
@@ -116,10 +191,19 @@ class CreateWalletAdapter(val context: Context, private val allListOfSeeds: Arra
         }
     }
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    inner class SeedViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val firstSeed = itemView.tvFirstSeed!!
         val secondSeed = itemView.tvSecondSeed!!
         val thirdSeed = itemView.tvThirdSeed!!
         val multiSeedPosition = itemView.tvCorrectWordNumber!!
     }
+
+    inner class HeaderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+
+    inner class FooterViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView){
+        val error: TextView = itemView.tvError
+        val confirmButton: Button = itemView.button_confirm_seed
+    }
+
+
 }

--- a/app/src/main/res/layout/verify_seed_footer.xml
+++ b/app/src/main/res/layout/verify_seed_footer.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/llButtons"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingLeft="8dp"
+    android:paddingRight="8dp"
+    android:paddingBottom="16dp"
+    android:visibility="visible">
+
+    <TextView
+        android:id="@+id/tvError"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingBottom="8dp"
+        android:textColor="@color/orangeTextColor"
+        android:visibility="gone"
+        tools:text="The big error"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/button_confirm_seed"
+        android:layout_width="151dp"
+        android:layout_height="42dp"
+        android:background="@drawable/btn_shape2"
+        android:text="@string/confirm"
+        android:textColor="@color/white"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/verify_seed_header.xml
+++ b/app/src/main/res/layout/verify_seed_header.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/headerTop"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/colorPrimary"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="8dp"
+        android:text="@string/seed_phrase_verification"
+        android:textColor="@color/darkBlueTextColor"
+        android:textSize="20sp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="start"
+        android:paddingStart="8dp"
+        android:paddingLeft="8dp"
+        android:paddingEnd="8dp"
+        android:paddingRight="8dp"
+        android:text="@string/please_confirm_your_seed_by_typing_and_tapping_each_word_accordingly"
+        android:textAllCaps="false"
+        android:textColor="@color/blueGraySecondTextColor"
+        android:textSize="14sp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/verify_seed_page.xml
+++ b/app/src/main/res/layout/verify_seed_page.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recyclerViewSeeds"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fadeScrollbars="true">
+
+</androidx.recyclerview.widget.RecyclerView>


### PR DESCRIPTION
This cancels out the need the to scroll manually while using the verify seed page.
![seed](https://user-images.githubusercontent.com/19960200/60846702-278bec00-a1d8-11e9-9bb6-20722a6351f0.gif)
