### PR TITLE
wallets: add fingerprint option to wallet security

### DIFF
--- a/app/src/main/java/com/dcrandroid/data/Constants.java
+++ b/app/src/main/java/com/dcrandroid/data/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
             BADGER_DB = "badgerdb",
             SPENDING_PASSPHRASE_TYPE = "spending_passphrase_type",
             STARTUP_PASSPHRASE = "startup_passphrase",
+            SPENDING_PASSPHRASE = "spending_passphrase",
             PIN = "pin",
             INSECURE_PUB_PASSPHRASE = "public",
             APP_VERSION = "app_version",

--- a/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
@@ -105,7 +105,7 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
                         showSuccess()
                     } catch (e: Exception) {
                         showSendButton()
-                        SnackBar.showError(container!!, R.string.send_fail_msg)
+                        SnackBar.showError(container!!, R.string.send_fail_msg) //TODO handle incorrect pass
                         e.printStackTrace()
                     }
                 }

--- a/app/src/main/java/com/dcrandroid/fragments/CreatePasswordPromptFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/CreatePasswordPromptFragment.kt
@@ -28,7 +28,10 @@ class CreatePasswordPromptFragment(var isSpending: Boolean, @StringRes var posit
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (!isSpending) {
+        if (isSpending) {
+            ed_pass.setHint(R.string.new_spending_password)
+            ed_confirm_pass.setHint(R.string.confirm_new_spending_password)
+        } else {
             ed_pass.setHint(R.string.new_startup_password)
             ed_confirm_pass.setHint(R.string.confirm_new_startup_password)
         }

--- a/app/src/main/java/com/dcrandroid/preference/SwitchPreference.kt
+++ b/app/src/main/java/com/dcrandroid/preference/SwitchPreference.kt
@@ -31,8 +31,11 @@ class SwitchPreference(context: Context, val key: String, val view: View, val ch
             newValue = checkChange.let { it(isChecked) }
         }
 
-        multiWallet!!.setBoolConfigValueForKey(key, newValue)
+        setValue(newValue)
+    }
 
+    fun setValue(newValue: Boolean) {
+        multiWallet!!.setBoolConfigValueForKey(key, newValue)
         setChecked(newValue)
     }
 

--- a/app/src/main/java/com/dcrandroid/util/BiometricUtils.kt
+++ b/app/src/main/java/com/dcrandroid/util/BiometricUtils.kt
@@ -63,17 +63,17 @@ object BiometricUtils {
         cipher.init(Cipher.ENCRYPT_MODE, secretKey)
 
         val iv = cipher.iv
-        saveToFile(context, Constants.ENCRYPTION_IV, iv)
+        saveToFile(context, Constants.ENCRYPTION_IV + alias, iv)
 
         val encryption = cipher.doFinal(content.toByteArray(StandardCharsets.UTF_8))
-        saveToFile(context, Constants.ENCRYPTION_DATA, encryption)
+        saveToFile(context, Constants.ENCRYPTION_DATA + alias, encryption)
     }
 
     @Throws(Exception::class)
     fun readFromKeystore(context: Context, alias: String): String {
 
-        val encryptionIv = readFromFile(context, Constants.ENCRYPTION_IV)
-        val encryptedData = readFromFile(context, Constants.ENCRYPTION_DATA)
+        val encryptionIv = readFromFile(context, Constants.ENCRYPTION_IV + alias)
+        val encryptedData = readFromFile(context, Constants.ENCRYPTION_DATA + alias)
 
         val keyStore = KeyStore.getInstance(Constants.ANDROID_KEY_STORE)
         keyStore.load(null)
@@ -104,6 +104,8 @@ object BiometricUtils {
 
         return false
     }
+
+    fun getWalletAlias(walletID: Long) = walletID.toString() + Constants.SPENDING_PASSPHRASE
 
     fun translateError(context: Context, errorCode: Int): String? {
         return when (errorCode) {

--- a/app/src/main/java/com/dcrandroid/util/ChangePassUtil.kt
+++ b/app/src/main/java/com/dcrandroid/util/ChangePassUtil.kt
@@ -68,6 +68,9 @@ class ChangePassUtil(private val fragmentActivity: FragmentActivity, val walletI
             } else {
                 try {
                     multiWallet.changePrivatePassphraseForWallet(walletID, oldPassphrase.toByteArray(), newPassphrase.toByteArray(), passphraseType)
+                    if (multiWallet.readBoolConfigValueForKey(walletID.toString() + Dcrlibwallet.UseFingerprintConfigKey, Constants.DEF_USE_FINGERPRINT)) {
+                        BiometricUtils.saveToKeystore(fragmentActivity, newPassphrase, BiometricUtils.getWalletAlias(walletID))
+                    }
                     SnackBar.showText(fragmentActivity, R.string.spending_passphrase_changed)
                 } catch (e: Exception) {
                     if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {

--- a/app/src/main/res/layout/activity_wallet_settings.xml
+++ b/app/src/main/res/layout/activity_wallet_settings.xml
@@ -131,7 +131,9 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:id="@+id/biometric_authentication"
+                    android:id="@+id/spendable_fingerprint"
+                    android:visibility="gone"
+                    tools:visibility="visible"
                     android:padding="@dimen/margin_padding_size_16"
                     android:gravity="center_vertical"
                     android:focusable="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -471,7 +471,9 @@
     <string name="a_wallet_needs_backup">A wallet needs backup</string>
     <string name="startup_password">Startup Password</string>
     <string name="new_startup_password">New startup password</string>
+    <string name="new_spending_password">New spending password</string>
     <string name="confirm_new_startup_password">Confirm new startup password</string>
+    <string name="confirm_new_spending_password">Confirm new spending password</string>
     <string name="remove_startup_security">Remove startup security</string>
     <string name="close_backup_warning">Close backup warning</string>
     <string name="close_backup_warning_dialog_message">Remember to back up your wallets as soon as possible.</string>
@@ -495,7 +497,7 @@
     <string name="rescan_blockchain">Rescan blockchain</string>
     <string name="rescan_progress_notification">Check progress in Overview!</string>
     <string name="rescan_blockchain_warning">Are you sure? This could take some time.</string>
-    <string name="err_sync_in_progress">Sync is in progress</string>
-    <string name="err_rescan_in_progress">A rescan is in progress</string>
+    <string name="err_sync_in_progress">Unable to start rescan while sync is in progress</string>
+    <string name="err_rescan_in_progress">Unable to start rescan while another rescan is already running</string>
 
 </resources>


### PR DESCRIPTION
This adds an option to enable fingerprint for spending password/PIN. The user’s passphrase is saved to the Android key store and retrieved when needed. The passphrase is also updated when the user changes the passphrase and cleared when deleting the wallet or disabling fingerprint.
Closes #409 