### PR TITLE
overview: show rescan progress when rescanning

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -54,6 +54,27 @@ class WalletSettings : BaseActivity() {
         change_spending_pass.setOnClickListener {
             ChangePassUtil(this, walletID).begin()
         }
+        
+        rescan_blockchain.setOnClickListener {
+            if (multiWallet!!.isSyncing) {
+                SnackBar.showError(this, R.string.err_sync_in_progress)
+            } else if (!multiWallet!!.isSynced) {
+                SnackBar.showError(this, R.string.not_connected)
+            } else if (multiWallet!!.isRescanning) {
+                SnackBar.showError(this, R.string.err_rescan_in_progress)
+            } else {
+                InfoDialog(this)
+                        .setDialogTitle(getString(R.string.rescan_blockchain))
+                        .setMessage(getString(R.string.rescan_blockchain_warning))
+                        .setPositiveButton(getString(R.string.yes), DialogInterface.OnClickListener { _, _ ->
+                            multiWallet!!.rescanBlocks(walletID)
+                            SnackBar.showText(this, R.string.rescan_progress_notification)
+                        })
+                        .setNegativeButton(getString(R.string.no))
+                        .show()
+            }
+
+        }
 
         remove_wallet.setOnClickListener {
             if (multiWallet!!.isSyncing || multiWallet!!.isSynced) {

--- a/app/src/main/java/com/dcrandroid/util/SyncLayoutUtil.kt
+++ b/app/src/main/java/com/dcrandroid/util/SyncLayoutUtil.kt
@@ -394,11 +394,11 @@ class SyncLayoutUtil(private val syncLayout: LinearLayout, restartSyncProcess: (
 
     override fun debug(debugInfo: DebugInfo?) {}
 
-    override fun onBlocksRescanStarted() {
+    override fun onBlocksRescanStarted(walletID: Long) {
         displaySyncingLayout()
     }
 
-    override fun onBlocksRescanEnded(e: java.lang.Exception?) {
+    override fun onBlocksRescanEnded(walletID: Long, e: java.lang.Exception?) {
         displaySyncedUnsynced()
     }
 

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -112,6 +112,27 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/check_statistics"
+                android:padding="@dimen/margin_padding_size_16"
+                android:focusable="true"
+                android:clickable="true"
+                android:background="@drawable/ripple"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@id/pref_title"
+                    android:includeFontPadding="false"
+                    android:text="@string/check_statistics"
+                    android:textColor="@color/darkBlueTextColor"
+                    android:fontFamily="@font/source_sans_pro"
+                    android:textSize="@dimen/edit_text_size_16" />
+
+            </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_wallet_settings.xml
+++ b/app/src/main/res/layout/activity_wallet_settings.xml
@@ -21,61 +21,60 @@
         android:background="@color/colorBackground"
         android:theme="@style/AppTheme.AppBarOverlay">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingStart="@dimen/margin_padding_size_16"
+            android:paddingEnd="0dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:padding="@dimen/margin_padding_size_8"
+                android:background="@drawable/circular_transparent_ripple"
+                android:focusable="true"
+                android:clickable="true"
+                android:id="@+id/go_back"
+                app:srcCompat="@drawable/ic_back" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@dimen/margin_padding_size_16"
-                android:paddingEnd="0dp"
-                android:orientation="horizontal"
-                android:gravity="center_vertical">
+                android:layout_marginStart="@dimen/margin_padding_size_8"
+                android:gravity="center_vertical"
+                android:orientation="vertical">
 
-                <ImageView
-                    android:layout_width="40dp"
-                    android:layout_height="40dp"
-                    android:padding="@dimen/margin_padding_size_8"
-                    android:background="@drawable/circular_transparent_ripple"
-                    android:focusable="true"
-                    android:clickable="true"
-                    android:id="@+id/go_back"
-                    app:srcCompat="@drawable/ic_back" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/settings"
+                    android:textSize="@dimen/edit_text_size_20"
+                    android:textColor="@color/darkBlueTextColor"
+                    android:includeFontPadding="false"
+                    app:fontFamily="@font/source_sans_pro" />
 
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_marginStart="@dimen/margin_padding_size_8"
-                    android:gravity="center_vertical"
-                    android:orientation="vertical"
-                    >
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/settings"
-                        android:textSize="@dimen/edit_text_size_20"
-                        android:textColor="@color/darkBlueTextColor"
-                        android:includeFontPadding="false"
-                        app:fontFamily="@font/source_sans_pro" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:id="@+id/tv_subtitle"
-                        tools:text="@string/_default"
-                        android:textSize="@dimen/edit_text_size_14"
-                        android:textColor="@color/blueGraySecondTextColor"
-                        android:includeFontPadding="false"
-                        app:fontFamily="@font/source_sans_pro" />
-
-                </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/tv_subtitle"
+                    tools:text="@string/_default"
+                    android:textSize="@dimen/edit_text_size_14"
+                    android:textColor="@color/blueGraySecondTextColor"
+                    android:includeFontPadding="false"
+                    app:fontFamily="@font/source_sans_pro" />
 
             </LinearLayout>
+
+        </LinearLayout>
 
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/wallet_settings_scroll_view" >
+        android:id="@+id/wallet_settings_scroll_view">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -92,7 +91,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -125,7 +124,7 @@
                         android:text="@string/change_spending_pin_password"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                 </LinearLayout>
 
@@ -154,7 +153,7 @@
                             android:text="@string/use_fingerprint"
                             android:textColor="@color/darkBlueTextColor"
                             android:fontFamily="@font/source_sans_pro"
-                            android:textSize="@dimen/edit_text_size_16"/>
+                            android:textSize="@dimen/edit_text_size_16" />
 
                     </LinearLayout>
 
@@ -176,7 +175,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -207,7 +206,7 @@
                         android:text="@string/incoming_transactions"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -218,7 +217,52 @@
                         android:text="@string/none"
                         android:textColor="@color/blueGraySecondTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_14"/>
+                        android:textSize="@dimen/edit_text_size_14" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_padding_size_4"
+                android:elevation="4dp"
+                android:orientation="vertical"
+                android:paddingTop="@dimen/margin_padding_size_16"
+                android:paddingBottom="@dimen/margin_padding_size_8"
+                android:background="@drawable/card_bg">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:includeFontPadding="false"
+                    android:text="@string/debug"
+                    android:textSize="@dimen/edit_text_size_14"
+                    android:fontFamily="@font/source_sans_pro"
+                    android:layout_marginStart="@dimen/margin_padding_size_16"
+                    android:textColor="@color/darkerBlueGrayTextColor" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/rescan_blockchain"
+                    android:layout_marginTop="@dimen/margin_padding_size_8"
+                    android:padding="@dimen/margin_padding_size_16"
+                    android:focusable="true"
+                    android:clickable="true"
+                    android:background="@drawable/ripple"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:id="@id/pref_title"
+                        android:includeFontPadding="false"
+                        android:text="@string/rescan_blockchain"
+                        android:textColor="@color/darkBlueTextColor"
+                        android:fontFamily="@font/source_sans_pro"
+                        android:textSize="@dimen/edit_text_size_16" />
 
                 </LinearLayout>
 
@@ -232,7 +276,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_8"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -252,7 +296,7 @@
                         android:text="@string/remove_wallet"
                         android:textColor="@color/orangeTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/layout/syncing_layout.xml
+++ b/app/src/main/res/layout/syncing_layout.xml
@@ -11,7 +11,7 @@
     android:id="@+id/syncing_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:visibility="gone"
+    android:visibility="visible"
     android:orientation="vertical">
 
     <LinearLayout
@@ -32,6 +32,7 @@
         <TextView
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:id="@+id/syncing_layout_status"
             android:layout_marginStart="@dimen/margin_padding_size_16"
             android:layout_weight="1"
             android:gravity="center_vertical"
@@ -110,8 +111,7 @@
                 android:includeFontPadding="false"
                 android:textColor="@color/darkBlueTextColor"
                 android:textSize="@dimen/edit_text_size_16"
-                app:fontFamily="@font/source_sans_pro"
-                 />
+                app:fontFamily="@font/source_sans_pro" />
 
         </LinearLayout>
 
@@ -226,7 +226,7 @@
 
             <include layout="@layout/multi_wallet_sync_details" />
 
-    </LinearLayout>
+        </LinearLayout>
 
         <View
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="exit_cap">EXIT</string>
     <string name="delete">Delete</string>
     <string name="no">No</string>
+    <string name="yes">Yes</string>
     <string name="confirm">Confirm</string>
     <string name="usd" translatable="false">USD</string>
     <string name="settings">Settings</string>
@@ -201,7 +202,7 @@
     <!--Error Messages-->
     <string name="not_enough_funds">Not enough funds.</string>
     <string name="empty_seed">Empty Seed</string>
-    <string name="not_connected">Not Connected To Decred Network</string>
+    <string name="not_connected">Not connected to Decred network</string>
     <string name="passphrase_required">Private Passphrase is required</string>
     <string name="wallet_not_loaded">Wallet Not Loaded</string>
     <string name="err_no_peers">Decred network is unreachable due to a lack of peers.</string>
@@ -316,6 +317,7 @@
     <string name="step_3_3">Step 3/3</string>
     <string name="fetching_block_headers"><![CDATA[Fetching block headers <font color="#8997a5">&centerdot;</font> %1$d%%]]></string>
     <string name="scanning_block_headers"><![CDATA[Scanning block headers <font color="#8997a5">&centerdot;</font> %1$d%%]]></string>
+    <string name="rescanning_blocks"><![CDATA[Rescanning blocks <font color="#8997a5">&centerdot;</font> %1$d%%]]></string>
     <string name="discovering_addresses"><![CDATA[Discovering used addresses <font color="#8997a5">&centerdot;</font> %1$d%%]]></string>
     <string name="syncing_progress">Syncing progress</string>
     <string name="percentage">%1$d%%</string>
@@ -482,11 +484,18 @@
     <string name="spending_passphrase_changed">Spending PIN/password changed</string>
     <string name="wallets_log">Wallets log</string>
     <string name="write_down_seed_phrase">Write down seed phrase</string>
-    <string name="step_1_2">Step 1/2</string>
+    <string name="step_1_2" tools:ignore="TypographyFractions">Step 1/2</string>
     <string name="your_33_word_seed_phrase">Your 33-word seed phrase</string>
     <string name="i_have_wrote_down_all_33_words">I have wrote down all 33 words</string>
     <string name="security_tools">Security Tools</string>
     <string name="security_tools_message">Various tools that help in different aspects of crypto currency security will be located here.</string>
     <string name="wallet_removed">Wallet removed</string>
+    <string name="rescanning_blocks_ellipsis">Rescanning Blocks…</string>
+    <string name="check_statistics">Check statistics</string>
+    <string name="rescan_blockchain">Rescan blockchain</string>
+    <string name="rescan_progress_notification">Check progress in Overview!</string>
+    <string name="rescan_blockchain_warning">Are you sure? This could take some time.</string>
+    <string name="err_sync_in_progress">Sync is in progress</string>
+    <string name="err_rescan_in_progress">A rescan is in progress</string>
 
 </resources>


### PR DESCRIPTION
Overview layout switches to a rescan setup when rescanning, showing the progress and estimated time left. There's also an option to view more details about the rescan progress.  
Closes #375 & #301   
Requires https://github.com/raedahgroup/dcrlibwallet/pull/78.  

<img src="https://user-images.githubusercontent.com/19960200/71317997-8b565880-248a-11ea-90df-0ff011c5a1ec.png" height="500">
<img src="https://user-images.githubusercontent.com/19960200/71317998-8c878580-248a-11ea-9db8-403b1924ec69.png" height="500">