### PR TITLE
multi: disable text fields when processing

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -14,6 +14,8 @@ import com.dcrandroid.R
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.CollapsedBottomSheetDialog
 import com.dcrandroid.dialog.InfoDialog
+import com.dcrandroid.dialog.PasswordPromptDialog
+import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.preference.ListPreference
 import com.dcrandroid.util.ChangePassUtil
 import com.dcrandroid.util.PassPromptTitle
@@ -88,9 +90,11 @@ class WalletSettings : BaseActivity() {
     private fun deleteWallet(pass: String, dialog: CollapsedBottomSheetDialog?) = GlobalScope.launch(Dispatchers.IO) {
         try {
             multiWallet!!.deleteWallet(walletID, pass.toByteArray())
+
             withContext(Dispatchers.Main) {
                 dialog?.dismiss()
             }
+
             if (multiWallet!!.openedWalletsCount() == 0) {
                 multiWallet!!.shutdown()
                 walletData.multiWallet = null
@@ -100,8 +104,17 @@ class WalletSettings : BaseActivity() {
                 setResult(Activity.RESULT_OK)
                 finish()
             }
+
+            SnackBar.showText(this@WalletSettings, R.string.wallet_removed)
         } catch (e: Exception) {
             e.printStackTrace()
+
+            if(dialog is PinPromptDialog){
+                dialog.setProcessing(false)
+            }else if(dialog is PasswordPromptDialog){
+                dialog.setProcessing(false)
+            }
+
             if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
                 val errMessage = when (wallet.privatePassphraseType) {
                     Dcrlibwallet.PassphraseTypePin -> R.string.invalid_pin

--- a/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
@@ -11,6 +11,7 @@ import android.view.ViewTreeObserver
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.data.Constants
+import com.dcrandroid.dialog.PasswordPromptDialog
 import com.dcrandroid.dialog.PinPromptDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
@@ -122,11 +123,11 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
         var dialog: PasswordPinDialogFragment? = null
         dialog = PasswordPinDialogFragment(R.string.create, false, isChange = false, passwordPinListener = object : PasswordPinDialogFragment.PasswordPinListener {
 
-            override fun onEnterPasswordOrPin(spendingKey: String, passphraseType: Int) {
+            override fun onEnterPasswordOrPin(newPassphrase: String, passphraseType: Int) {
                 GlobalScope.launch(Dispatchers.IO) {
                     try {
-                        BiometricUtils.saveToKeystore(this@SettingsActivity, spendingKey, Constants.STARTUP_PASSPHRASE)
-                        multiWallet!!.changePublicPassphrase(ByteArray(0), spendingKey.toByteArray())
+                        BiometricUtils.saveToKeystore(this@SettingsActivity, newPassphrase, Constants.STARTUP_PASSPHRASE)
+                        multiWallet!!.changePublicPassphrase(ByteArray(0), newPassphrase.toByteArray())
                         multiWallet!!.setInt32ConfigValueForKey(Dcrlibwallet.StartupSecurityTypeConfigKey, passphraseType)
                         multiWallet!!.setBoolConfigValueForKey(Dcrlibwallet.IsStartupSecuritySetConfigKey, true)
 
@@ -172,7 +173,11 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
                     e.printStackTrace()
                     if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
                         if (dialog is PinPromptDialog) {
-                            dialog.showError() // TODO
+                            dialog.setProcessing(false)
+                            dialog.showError()
+                        }else if(dialog is PasswordPromptDialog){
+                            dialog.setProcessing(false)
+                            dialog.showError()
                         }
                     }
                 }

--- a/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PinPromptDialog.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.*
 class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boolean,
                       val passEntered: (dialog: CollapsedBottomSheetDialog, passphrase: String?) -> Boolean) : CollapsedBottomSheetDialog() {
 
-    var confirmed = false
     var hint = R.string.enter_spending_pin
     private lateinit var pinViewUtil: PinViewUtil
 
@@ -79,7 +78,21 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
 
             btn_cancel.isEnabled = true
         }
+    }
 
+    fun setProcessing(processing: Boolean) = GlobalScope.launch(Dispatchers.Main){
+        pinViewUtil.pinView.rejectInput = processing
+        btn_cancel.isEnabled = !processing
+
+        if(processing){
+            btn_confirm.hide()
+            progress_bar.show()
+        }else{
+            btn_confirm.show()
+            progress_bar.hide()
+
+            btn_confirm.isEnabled = pinViewUtil.passCode.isNotEmpty()
+        }
     }
 
     private fun onEnter() {
@@ -87,9 +100,7 @@ class PinPromptDialog(@StringRes val dialogTitle: Int, val isSpendingPass: Boole
         if (dismissDialog) {
             dismiss()
         } else {
-            btn_cancel.isEnabled = false
-            progress_bar.show()
-            btn_confirm.hide()
+            setProcessing(true)
         }
     }
 }

--- a/app/src/main/java/com/dcrandroid/fragments/CreatePasswordPromptFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/CreatePasswordPromptFragment.kt
@@ -18,7 +18,7 @@ import com.dcrandroid.R
 import dcrlibwallet.Dcrlibwallet
 import kotlinx.android.synthetic.main.create_password_sheet.*
 
-class CreatePasswordPromptFragment(var isSpending: Boolean, @StringRes var positiveButtonTitle: Int, private var clickListener: DialogButtonListener) : Fragment() {
+class CreatePasswordPromptFragment(var isSpending: Boolean, @StringRes var positiveButtonTitle: Int, val createWallet:(passphrase: String?) -> Unit) : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
@@ -54,19 +54,19 @@ class CreatePasswordPromptFragment(var isSpending: Boolean, @StringRes var posit
             true
         }
 
-        btn_cancel.setOnClickListener { clickListener.onClickCancel() }
+        btn_cancel.setOnClickListener { createWallet(null) }
 
         btn_create.setText(positiveButtonTitle)
         btn_create.setOnClickListener {
             it.visibility = View.GONE
-            ed_pass.isFocusable = false
-            ed_confirm_pass.isFocusable = false
+            ed_pass.isEnabled = false
+            ed_confirm_pass.isEnabled = false
 
             btn_cancel.isEnabled = false
             btn_cancel.setTextColor(resources.getColor(R.color.colorDisabled))
             progress_bar.visibility = View.VISIBLE
 
-            clickListener.onClickOk(ed_pass.textString)
+            createWallet(ed_pass.textString)
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/fragments/CreatePinPromptFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/CreatePinPromptFragment.kt
@@ -21,7 +21,7 @@ import kotlinx.android.synthetic.main.create_pin_sheet.*
 import kotlinx.coroutines.*
 
 class CreatePinPromptFragment(var isSpending: Boolean, @StringRes var positiveButtonTitle: Int,
-                              private var clickListener: DialogButtonListener) : Fragment() {
+                              private val createWallet:(passphrase: String?) -> Unit?) : Fragment() {
 
     private var currentPassCode: String? = null
     private lateinit var pinViewUtil: PinViewUtil
@@ -56,7 +56,7 @@ class CreatePinPromptFragment(var isSpending: Boolean, @StringRes var positiveBu
             onEnter()
         }
 
-        btn_cancel.setOnClickListener { clickListener.onClickCancel() }
+        btn_cancel.setOnClickListener { createWallet(null) }
         btn_back.setOnClickListener {
             currentPassCode = null
             pinViewUtil.reset()
@@ -97,7 +97,7 @@ class CreatePinPromptFragment(var isSpending: Boolean, @StringRes var positiveBu
                 btn_cancel.isEnabled = false
                 btn_cancel.setTextColor(resources.getColor(R.color.colorDisabled))
 
-                clickListener.onClickOk(currentPassCode!!)
+                createWallet(currentPassCode!!)
 
             }
             else -> {

--- a/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
@@ -123,6 +123,10 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
         val coinbaseTxCount = wallet!!.countTransactions(Dcrlibwallet.TxFilterCoinBase)
 
         withContext(Dispatchers.Main) {
+            if(context == null){
+                return@withContext
+            }
+
             availableTxTypes.add(context!!.getString(R.string.tx_sort_all, txCount))
             availableTxTypes.add(context!!.getString(R.string.tx_sort_sent, sentTxCount))
             availableTxTypes.add(context!!.getString(R.string.tx_sort_received, receivedTxCount))

--- a/app/src/main/java/com/dcrandroid/view/PasswordInput.kt
+++ b/app/src/main/java/com/dcrandroid/view/PasswordInput.kt
@@ -183,4 +183,11 @@ class PasswordInput : FrameLayout, TextWatcher {
         hintTextView.setTextColor(textColor)
         getChildAt(0).input_layout.setBackgroundResource(backgroundResource)
     }
+
+    override fun setEnabled(enabled: Boolean){
+        super.setEnabled(enabled)
+        ivConcealReveal.isEnabled = enabled
+        editText.isEnabled = enabled
+    }
+
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,9 +7,6 @@
 
 <resources>
 
-    <!--Old blue theme-->
-    <!--/Old blue theme-->
-
     <!--Light theme-->
 
     <!--General-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -487,5 +487,6 @@
     <string name="i_have_wrote_down_all_33_words">I have wrote down all 33 words</string>
     <string name="security_tools">Security Tools</string>
     <string name="security_tools_message">Various tools that help in different aspects of crypto currency security will be located here.</string>
+    <string name="wallet_removed">Wallet removed</string>
 
 </resources>


### PR DESCRIPTION
Password text fields and passcode entries are editable while it is processing which shouldn't be allowed. This commit fixes that by disabling the UI and the caller has a function to re-enable the UI in the case of an incorrect passphrase or an error occurred.  

Closes #418   

<img src="https://user-images.githubusercontent.com/19960200/71438395-ecce2f80-26f5-11ea-8e93-73c332bf9bf6.png" height="500">