### PR TITLE
security: add validate addresses activity to security tools

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -140,6 +140,10 @@
             android:launchMode="singleTask" />
 
         <activity
+            android:name=".activities.more.SecurityTools"
+            android:launchMode="singleTask" />
+
+        <activity
             android:name=".activities.more.HelpActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:launchMode="singleTask" />

--- a/app/src/main/java/com/dcrandroid/activities/more/SecurityTools.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SecurityTools.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2019 The Decred developers
+ * Use of this source code is governed by an ISC
+ * license that can be found in the LICENSE file.
+ */
+
+package com.dcrandroid.activities.more
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.dcrandroid.R
+import com.dcrandroid.activities.BaseActivity
+import com.dcrandroid.activities.security.ValidateAddress
+import com.dcrandroid.dialog.InfoDialog
+import com.dcrandroid.fragments.more.ListAdapter
+import com.dcrandroid.fragments.more.ListItem
+import kotlinx.android.synthetic.main.activity_security_tools.*
+
+class SecurityTools : BaseActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_security_tools)
+
+        iv_info.setOnClickListener {
+            InfoDialog(this)
+                    .setDialogTitle(getString(R.string.security_tools))
+                    .setMessage(getString(R.string.security_tools_message))
+                    .setPositiveButton(getString(R.string.got_it), null)
+                    .show()
+        }
+
+        go_back.setOnClickListener {
+            finish()
+        }
+
+        val items = arrayOf(
+                ListItem(R.string.validate_addresses, R.drawable.ic_location_pin, Intent(this, ValidateAddress::class.java)))
+
+        val adapter = ListAdapter(this, items)
+        security_tools_recycler_view.layoutManager = LinearLayoutManager(this)
+        security_tools_recycler_view.adapter = adapter
+    }
+
+
+}

--- a/app/src/main/java/com/dcrandroid/activities/security/ValidateAddress.kt
+++ b/app/src/main/java/com/dcrandroid/activities/security/ValidateAddress.kt
@@ -10,25 +10,19 @@ import android.os.Bundle
 import android.view.View
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
-import com.dcrandroid.data.Constants
 import com.dcrandroid.extensions.hide
+import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.extensions.show
 import com.dcrandroid.view.util.InputHelper
-import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.activity_validate_address.*
 
 class ValidateAddress : BaseActivity(), View.OnClickListener {
 
     lateinit var addressInputHelper: InputHelper
 
-    lateinit var wallet: Wallet
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_validate_address)
-
-        val walletID = intent.getLongExtra(Constants.WALLET_ID, -1)
-        wallet = multiWallet!!.walletWithID(walletID)
 
         addressInputHelper = InputHelper(this, address_container) {
             // no validation for address input
@@ -49,47 +43,58 @@ class ValidateAddress : BaseActivity(), View.OnClickListener {
     override fun onClick(v: View) {
 
         when (v.id) {
-            R.id.tv_validate -> {
-                result_layout.show()
-
-                val address = addressInputHelper.validatedInput!!
-
-                val icon: Int
-                val titleText: Int
-                var subtitleText: Int? = null
-
-                if (wallet.isAddressValid(address)) {
-                    tv_title.setTextColor(getColor(R.color.greenTextColor))
-                    tv_subtitle.show()
-                    icon = R.drawable.ic_checkmark
-                    titleText = R.string.valid_address
-
-                    if (wallet.haveAddress(address)) {
-                        subtitleText = R.string.internal_valid_address
-                        tv_subtitle.setTextColor(getColor(R.color.greenLightTextColor))
-                    } else {
-                        subtitleText = R.string.external_valid_address
-                        tv_subtitle.setTextColor(getColor(R.color.lightGrayTextColor))
-                    }
-
-                } else {
-                    tv_title.setTextColor(getColor(R.color.colorError))
-                    icon = R.drawable.ic_crossmark
-                    titleText = R.string.invalid_address
-
-                    tv_subtitle.hide()
-                }
-
-                tv_title.setText(titleText)
-                if (subtitleText != null) {
-                    tv_subtitle.setText(subtitleText)
-                }
-                iv_result_icon.setImageResource(icon)
-            }
+            R.id.tv_validate -> validateAddress()
 
             R.id.tv_clear -> addressInputHelper.editText.text = null
 
             else -> finish() // R.id.go_back
         }
+    }
+
+    private fun validateAddress() {
+
+        val wallets = multiWallet!!.openedWalletsList()
+
+        val address = addressInputHelper.validatedInput!!
+
+        var icon = R.drawable.ic_crossmark
+        var titleText = R.string.invalid_address
+        var subtitleText: String? = null
+
+        var foundAddress = false
+
+        for (wallet in wallets) {
+
+            if (wallet.isAddressValid(address)) {
+                foundAddress = true
+
+                tv_title.setTextColor(getColor(R.color.greenTextColor))
+                tv_subtitle.show()
+
+                icon = R.drawable.ic_checkmark
+                titleText = R.string.valid_address
+
+                if (wallet.haveAddress(address)) {
+                    subtitleText = getString(R.string.internal_valid_address, wallet.name)
+                    tv_subtitle.setTextColor(getColor(R.color.greenLightTextColor))
+                    break
+                } else {
+                    subtitleText = getString(R.string.external_valid_address)
+                    tv_subtitle.setTextColor(getColor(R.color.lightGrayTextColor))
+                }
+            }
+        }
+
+        result_layout.show()
+        if (!foundAddress) {
+            tv_title.setTextColor(getColor(R.color.colorError))
+            tv_subtitle.hide()
+        }
+
+        tv_title.setText(titleText)
+        if (subtitleText != null) {
+            tv_subtitle.text = subtitleText
+        }
+        iv_result_icon.setImageResource(icon)
     }
 }

--- a/app/src/main/java/com/dcrandroid/fragments/more/MoreFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/more/MoreFragment.kt
@@ -13,10 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.dcrandroid.R
-import com.dcrandroid.activities.more.AboutActivity
-import com.dcrandroid.activities.more.DebugActivity
-import com.dcrandroid.activities.more.HelpActivity
-import com.dcrandroid.activities.more.SettingsActivity
+import com.dcrandroid.activities.more.*
 import com.dcrandroid.fragments.BaseFragment
 import kotlinx.android.synthetic.main.fragment_more.*
 
@@ -33,6 +30,7 @@ class MoreFragment : BaseFragment() {
 
         val items = arrayOf(
                 ListItem(R.string.settings, R.drawable.ic_settings, Intent(context, SettingsActivity::class.java)),
+                ListItem(R.string.security_tools, R.drawable.ic_security, Intent(context, SecurityTools::class.java)),
                 ListItem(R.string.help, R.drawable.ic_question_mark, Intent(context, HelpActivity::class.java)),
                 ListItem(R.string.about, R.drawable.ic_info1, Intent(context, AboutActivity::class.java)),
                 ListItem(R.string.debug, R.drawable.ic_debug, Intent(context, DebugActivity::class.java)))

--- a/app/src/main/res/drawable/ic_location_pin.xml
+++ b/app/src/main/res/drawable/ic_location_pin.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20,9.3333C19.9998,6.4752 18.4749,3.8343 15.9996,2.4054C13.5243,0.9764 10.4747,0.9766 7.9996,2.4058C5.5245,3.835 3.9998,6.4761 4,9.3342L4,10.6906C9.2373,16.1491 14.5687,16.2555 20,10.7092L20,9.3333ZM12,12.0008C10.1591,12.0008 8.6667,10.5084 8.6667,8.6675C8.6667,6.8265 10.1591,5.3341 12,5.3341C13.8409,5.3341 15.3333,6.8265 15.3333,8.6675C15.3333,9.5515 14.9821,10.3994 14.357,11.0245C13.7319,11.6496 12.8841,12.0008 12,12.0008L12,12.0008Z"
+      android:strokeWidth="1"
+      android:fillColor="#091440"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M12,2.6667C7.5817,2.6667 4,6.2484 4,10.6667C4,17.3605 12,22.6649 12,22.6649C12,22.6649 20,17.3604 20,10.6667C20,6.2484 16.4183,2.6667 12,2.6667ZM12,13.3333C10.1591,13.3333 8.6667,11.8409 8.6667,10C8.6667,8.1591 10.1591,6.6667 12,6.6667C13.8409,6.6667 15.3333,8.1591 15.3333,10C15.3333,10.8841 14.9821,11.7319 14.357,12.357C13.7319,12.9821 12.8841,13.3333 12,13.3333Z"
+      android:strokeWidth="1"
+      android:fillColor="#C4CBD2"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_security.xml
+++ b/app/src/main/res/drawable/ic_security.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M4,9.1667l16,0l0,10.4592l-16,0z"
+      android:strokeWidth="1"
+      android:fillColor="#C4CBD2"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M4,11.8019l16,0l0,10.8645l-16,0z"
+      android:strokeWidth="1"
+      android:fillColor="#091440"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M5.5139,7.8659L5.5139,10.4999L8.1059,10.4999L8.1059,7.8659C8.1046,5.6957 9.861,3.9345 12.0312,3.9299L12.0419,3.9299C14.212,3.9286 15.9732,5.685 15.9779,7.8552L15.9779,10.4952L18.5699,10.4952L18.5699,7.8609C18.5658,4.2572 15.6455,1.337 12.0419,1.3329C8.437,1.3387 5.517,4.261 5.5139,7.8659Z"
+      android:strokeWidth="1"
+      android:fillColor="#091440"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M12.0419,13.842C9.6272,13.8211 7.3945,15.1227 6.2229,17.2342C7.425,19.3157 9.6383,20.606 12.0419,20.6265C14.4541,20.638 16.6823,19.339 17.8608,17.2342C16.6586,15.153 14.4453,13.8627 12.0419,13.842L12.0419,13.842Z"
+      android:strokeWidth="1"
+      android:fillColor="#C4CBD2"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+  <path
+      android:pathData="M12.0421,17.2274L13.855,15.3767C12.9733,14.5138 11.6054,14.3922 10.5852,15.0859C9.565,15.7797 9.1753,17.0965 9.6537,18.2338C10.1321,19.371 11.3459,20.0133 12.5552,19.7692C13.7646,19.5251 14.6342,18.4622 14.634,17.2284L14.634,17.2274L12.0421,17.2274Z"
+      android:strokeWidth="1"
+      android:fillColor="#091440"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000"/>
+</vector>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -36,7 +36,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@dimen/margin_padding_size_16"
+                android:paddingStart="@dimen/margin_padding_size_8"
                 android:paddingEnd="0dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical">

--- a/app/src/main/res/layout/activity_debug.xml
+++ b/app/src/main/res/layout/activity_debug.xml
@@ -36,7 +36,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@dimen/margin_padding_size_16"
+                android:paddingStart="@dimen/margin_padding_size_8"
                 android:paddingEnd="0dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical">
@@ -56,8 +56,7 @@
                     android:layout_height="match_parent"
                     android:layout_marginStart="@dimen/margin_padding_size_8"
                     android:gravity="center_vertical"
-                    android:orientation="vertical"
-                    >
+                    android:orientation="vertical">
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -89,8 +88,7 @@
             android:layout_margin="@dimen/margin_padding_size_4"
             android:elevation="4dp"
             android:orientation="vertical"
-            android:background="@drawable/card_bg"
-            >
+            android:background="@drawable/card_bg">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -110,7 +108,7 @@
                     android:text="@string/check_wallets_log"
                     android:textColor="@color/darkBlueTextColor"
                     android:fontFamily="@font/source_sans_pro"
-                    android:textSize="@dimen/edit_text_size_16"/>
+                    android:textSize="@dimen/edit_text_size_16" />
 
             </LinearLayout>
 
@@ -133,7 +131,7 @@
                     android:text="@string/logging_level"
                     android:textColor="@color/darkBlueTextColor"
                     android:fontFamily="@font/source_sans_pro"
-                    android:textSize="@dimen/edit_text_size_16"/>
+                    android:textSize="@dimen/edit_text_size_16" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -144,7 +142,7 @@
                     android:text="@string/logging_level"
                     android:textColor="@color/blueGraySecondTextColor"
                     android:fontFamily="@font/source_sans_pro"
-                    android:textSize="@dimen/edit_text_size_14"/>
+                    android:textSize="@dimen/edit_text_size_14" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/activity_help.xml
+++ b/app/src/main/res/layout/activity_help.xml
@@ -36,7 +36,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@dimen/margin_padding_size_16"
+                android:paddingStart="@dimen/margin_padding_size_8"
                 android:paddingEnd="0dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical">

--- a/app/src/main/res/layout/activity_security_tools.xml
+++ b/app/src/main/res/layout/activity_security_tools.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@color/colorBackground"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/top_bar"
+        android:padding="8dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:padding="@dimen/margin_padding_size_8"
+            android:background="@drawable/circular_transparent_ripple"
+            android:focusable="true"
+            android:clickable="true"
+            android:id="@+id/go_back"
+            app:srcCompat="@drawable/ic_back" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_padding_size_8"
+            android:text="@string/security_tools"
+            android:textSize="@dimen/edit_text_size_20"
+            android:textColor="@color/darkBlueTextColor"
+            android:includeFontPadding="false"
+            app:fontFamily="@font/source_sans_pro" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="end">
+
+            <ImageView
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:id="@+id/iv_info"
+                android:padding="@dimen/margin_padding_size_8"
+                app:srcCompat="@drawable/ic_info"
+                android:focusable="true"
+                android:clickable="true"
+                android:background="@drawable/circular_transparent_ripple" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/security_tools_recycler_view" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_validate_address.xml
+++ b/app/src/main/res/layout/activity_validate_address.xml
@@ -37,7 +37,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@dimen/margin_padding_size_16"
+                android:paddingStart="@dimen/margin_padding_size_8"
                 android:paddingEnd="0dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical">
@@ -56,7 +56,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/validate_addresses"
-                    android:layout_marginStart="@dimen/margin_padding_size_16"
+                    android:layout_marginStart="@dimen/margin_padding_size_8"
                     android:textSize="@dimen/edit_text_size_20"
                     android:textColor="@color/darkBlueTextColor"
                     android:includeFontPadding="false"
@@ -142,8 +142,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
-                android:background="#e6eaed"
-                />
+                android:background="#e6eaed" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -151,21 +150,19 @@
                 android:orientation="horizontal"
                 android:gravity="center_vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
-                android:paddingBottom="@dimen/margin_padding_size_16"
-                >
+                android:paddingBottom="@dimen/margin_padding_size_16">
 
                 <ImageView
                     android:layout_width="24dp"
                     android:layout_height="24dp"
                     android:id="@+id/iv_result_icon"
-                    android:src="@drawable/ic_checkmark"/>
+                    android:src="@drawable/ic_checkmark" />
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    android:layout_marginStart="@dimen/margin_padding_size_8"
-                    >
+                    android:layout_marginStart="@dimen/margin_padding_size_8">
 
                     <TextView
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -24,7 +24,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:paddingStart="@dimen/margin_padding_size_16"
+            android:paddingStart="@dimen/margin_padding_size_8"
             android:paddingEnd="0dp"
             android:orientation="horizontal"
             android:gravity="center_vertical">
@@ -44,8 +44,7 @@
                 android:layout_height="match_parent"
                 android:layout_marginStart="@dimen/margin_padding_size_8"
                 android:gravity="center_vertical"
-                android:orientation="vertical"
-                >
+                android:orientation="vertical">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -65,7 +64,7 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/settings_scroll_view" >
+        android:id="@+id/settings_scroll_view">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -82,7 +81,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -115,7 +114,7 @@
                         android:text="@string/unconfirmed_funds"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:layout_width="wrap_content"
@@ -143,7 +142,7 @@
                         android:text="@string/currency_conversion"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -154,7 +153,7 @@
                         android:text="@string/none"
                         android:textColor="@color/blueGraySecondTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_14"/>
+                        android:textSize="@dimen/edit_text_size_14" />
 
                 </LinearLayout>
 
@@ -168,7 +167,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -201,7 +200,7 @@
                         android:text="@string/startup_pin_password"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:layout_width="wrap_content"
@@ -232,7 +231,7 @@
                         android:text="@string/use_fingerprint"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:layout_width="wrap_content"
@@ -263,7 +262,7 @@
                         android:text="@string/change_startup_pin_password"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                 </LinearLayout>
 
@@ -277,7 +276,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg" >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -309,7 +308,7 @@
                         android:text="@string/beep_for_new_blocks"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:layout_width="wrap_content"
@@ -329,8 +328,7 @@
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"
                 android:paddingBottom="@dimen/margin_padding_size_8"
-                android:background="@drawable/card_bg"
-                >
+                android:background="@drawable/card_bg">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -363,7 +361,7 @@
                         android:text="@string/wifi_data_sync_title"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:layout_width="wrap_content"
@@ -391,7 +389,7 @@
                         android:text="@string/connect_to_specific_peer"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -402,7 +400,7 @@
                         tools:text="10.0.2.2"
                         android:textColor="@color/blueGraySecondTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_14"/>
+                        android:textSize="@dimen/edit_text_size_14" />
 
                 </LinearLayout>
 
@@ -424,7 +422,7 @@
                         android:text="@string/user_agent"
                         android:textColor="@color/darkBlueTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_16"/>
+                        android:textSize="@dimen/edit_text_size_16" />
 
                     <TextView
                         android:layout_width="wrap_content"
@@ -435,7 +433,7 @@
                         android:text="@string/user_agent_summary"
                         android:textColor="@color/blueGraySecondTextColor"
                         android:fontFamily="@font/source_sans_pro"
-                        android:textSize="@dimen/edit_text_size_14"/>
+                        android:textSize="@dimen/edit_text_size_14" />
 
                 </LinearLayout>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -4,511 +4,248 @@
   ~ license that can be found in the LICENSE file.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
        <!--General-->
-       <string name="wallet">钱包</string>
-       <string name="crash_dialog_text">一项意外错误导致应用被强制终止。请点击“确定”向我们发送您的设备规范和应用日志以帮助我们解决此问题。这将有助于我们防止错误的再次发生</string><![CDATA[
        
-       
-       
-       
-       
-       
-       
-       ]]><string name="send_dcr_info">输入或扫描目标地址并输入发送的DCR数目。</string><![CDATA[
-       
-       ]]>
+    <string name="wallet">钱包</string>
+    <string name="crash_dialog_text">一项意外错误导致应用被强制终止。请点击“确定”向我们发送您的设备规范和应用日志以帮助我们解决此问题。这将有助于我们防止错误的再次发生</string>
+    <string name="send_dcr_info">输入或扫描目标地址并输入发送的DCR数目。</string>
     <string name="type">类别</string>
-       <string name="loading">加载中</string><![CDATA[
-       
-       
-       ]]><string name="help">帮助</string><![CDATA[
-       
-       ]]>
+    <string name="loading">加载中</string>
+    <string name="help">帮助</string>
     <string name="overview">概览</string>
-       <string name="permission">权限范围</string>
-       <string name="denied_permission">超出权限范围</string><![CDATA[
-       
-       ]]><string name="receive">接收</string><![CDATA[
-       
-       
-       ]]><string name="send">发送</string><![CDATA[
-       
-       ]]><string name="cancel">取消</string><![CDATA[
-       
-       
-       ]]><string name="connection">连接</string><![CDATA[
-       
-       
-       ]]>
+    <string name="permission">权限范围</string>
+    <string name="denied_permission">超出权限范围</string>
+    <string name="receive">接收</string>
+    <string name="send">发送</string>
+    <string name="cancel">取消</string>
+    <string name="connection">连接</string>
     <string name="testnet">测试网</string>
-       <string name="general">通用</string>
-       <string name="view_on_dcrdata">在 dcrdata 查看</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]>
+    <string name="general">通用</string>
+    <string name="view_on_dcrdata">在 dcrdata 查看</string>
     <string name="default_account">默认账号</string>
-       <string name="exit_cap">退出</string><![CDATA[
-       
-       ]]>
+    <string name="exit_cap">退出</string>
     <string name="delete">删除</string>
-       <string name="no">否</string><![CDATA[
-       
-       ]]><string name="confirm">确认</string><![CDATA[
-       
-       
-       ]]><string name="settings">设置</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]>
+    <string name="no">否</string>
+    <string name="confirm">确认</string>
+    <string name="settings">设置</string>
     <string name="ok">OK</string>
-       <string name="user_agent">用户代理</string>
-       <string name="log_file_not_found">未发现日志文件</string>
-       <string name="wallet_log_copied">钱包日志复制成功</string><![CDATA[
+    <string name="user_agent">用户代理</string>
+    <string name="log_file_not_found">未发现日志文件</string>
        
+    <string name="wallet_log_copied">钱包日志复制成功</string>
+    <string name="one_day">1 天</string>
+    <string name="copy">复制</string>
+    <string name="address_not_found">找不到地址</string>
        
-       
-       
-       
-       ]]><string name="one_day">1 天</string><![CDATA[
-       
-       
-       
-       ]]><string name="copy">复制</string><![CDATA[
-       
-       
-       
-       ]]><string name="address_not_found">找不到地址</string><![CDATA[
-       
-       
-       ]]>
     <string name="share">分享</string>
-       <string name="clear_fields">清除</string><![CDATA[
        
-       ]]>
+    <string name="clear_fields">清除</string>
     <string name="retry_caps">重试</string>
-       <string name="share_address_via">分享二维码</string><![CDATA[
+       
+    <string name="share_address_via">分享二维码</string><!--/General-->
 
+       <!--Peers-->
+    <string name="version">版本</string>
        
-       ]]><!--/General-->
+    <string name="connecting_to_peers">正在连接节点</string><!--/Peers-->
 
-       <!--Peers--><![CDATA[
+       <!--Account-->
        
+    <string name="account_number">账户序号</string>
+    <string name="account_name">账户名</string>
        
-       
-       
-       
-       
-       
-       ]]><string name="version">版本</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><string name="connecting_to_peers">正在连接节点</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       ]]><!--/Peers-->
-
-       <!--Account--><![CDATA[
-       
-       
-       ]]><string name="account_number">账户序号</string><![CDATA[
-       
-       
-       
-       ]]><string name="account_name">账户名</string><![CDATA[
-       
-       
-       
-       
-       ]]><string name="hd_path">HD路径</string><![CDATA[
-       
-       ]]><string name="external">外部</string><![CDATA[
-       
-       
-       ]]><!--/Account-->
+    <string name="hd_path">HD路径</string>
+    <string name="external">外部</string>
+       <!--/Account-->
 
        <!--Seed-->
-       <string name="save_seed_instruction">请将种子写下并安全保存。在下个页面及以后需要恢复钱包时都需要输入种子</string><![CDATA[
        
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><!--/Seed-->
+    <string name="save_seed_instruction">请将种子写下并安全保存。在下个页面及以后需要恢复钱包时都需要输入种子</string>
+       <!--/Seed-->
 
        <!--Balance-->
-       <string name="label_spendable">可用资金</string>
-       <string name="immature_stake_generation">生成未成熟票</string>
-       <string name="label_immature_rewards">未成熟奖励</string>
-       <string name="label_locked_by_tickets">选票锁定</string>
-       <string name="label_voting_authority">投票权</string>
-       <string name="current_total_balance">总余额</string><![CDATA[
        
+    <string name="label_spendable">可用资金</string>
        
+    <string name="immature_stake_generation">生成未成熟票</string>
        
-       ]]>
+    <string name="label_immature_rewards">未成熟奖励</string>
+       
+    <string name="label_locked_by_tickets">选票锁定</string>
+       
+    <string name="label_voting_authority">投票权</string>
+       
+    <string name="current_total_balance">总余额</string>
     <string name="total_balance">总余额</string>
        <!--/Balance-->
 
-       <!--Wallet--><![CDATA[
+       <!--Wallet-->
        
-       
-       ]]>
     <string name="create_a_new_wallet">创建新钱包</string>
-       <string name="restore_existing_wallet">恢复现有钱包</string><![CDATA[
        
+    <string name="restore_existing_wallet">恢复现有钱包</string>
        
-       ]]><string name="opening_wallet">正在打开钱包…</string><![CDATA[
-       
-       
-       
-       ]]>
+    <string name="opening_wallet">正在打开钱包…</string>
     <string name="invalid_passphrase">密码错误。</string>
-       <string name="invalid_pin">输入的PIN错误。</string><![CDATA[
        
-       ]]><string name="invalid_password">输入的密码错误。</string><![CDATA[
+    <string name="invalid_pin">输入的PIN错误。</string>
+    <string name="invalid_password">输入的密码错误。</string>
        
-       
-       ]]>
     <string name="failed_to_open_wallet">打开钱包失败</string>
        <!--/Wallet-->
 
        <!--Transaction-->
-       <string name="recent_transactions">最近交易</string><![CDATA[
        
+    <string name="recent_transactions">最近交易</string>
        
-       
-       
-       
-       
-       ]]><string name="destination_address">目的地址</string><![CDATA[
-       
-       ]]>
+    <string name="destination_address">目的地址</string>
     <string name="transaction_fee">交易手续费</string>
-       <string name="Transaction_details">交易详情</string><![CDATA[
        
+    <string name="Transaction_details">交易详情</string>
        
+    <string name="pending">等待</string>
        
-       
-       
-       
-       
-       
-       
-       
-       ]]><string name="pending">等待</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       ]]><string name="vote">已投票</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><string name="amount_invalid_decimal_places">金额超过8位小数</string><![CDATA[
-       
-       ]]><string name="new_transaction">新的交易</string><![CDATA[
-       
-       
-       
-       
-       
-       ]]><!--/Transaction-->
+    <string name="vote">已投票</string>
+    <string name="amount_invalid_decimal_places">金额超过8位小数</string>
+    <string name="new_transaction">新的交易</string><!--/Transaction-->
 
-       <!--Block chain--><![CDATA[
-       
-       
-       
-       
-       ]]><!--/Block chain-->
+       <!--Block chain-->
+       <!--/Block chain-->
 
-       <!--Sync Messages--><![CDATA[
-       
-       
-       
-       ]]>
+       <!--Sync Messages-->
     <string name="remaining_minute_sync_eta">已完成 %1$d%%, 剩余 %2$d 分钟</string>
-       <string name="remaining_seconds_sync_eta">已完成 %1$d%%, 剩余 %2$d 秒</string>
-       <string name="remaining_sync_eta_less_than_seconds">已完成 %1$d%%, 剩余 &lt;1 秒</string><![CDATA[
        
+    <string name="remaining_seconds_sync_eta">已完成 %1$d%%, 剩余 %2$d 秒</string>
        
+    <string name="remaining_sync_eta_less_than_seconds">已完成 %1$d%%, 剩余 &lt;1 秒</string>
        
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><string name="synchronizing">正在同步</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><!--/Sync Messages-->
+    <string name="synchronizing">正在同步</string><!--/Sync Messages-->
 
        <!--QR Code-->
-       <string name="camera_permission_scan">这个应用需要相机权限来扫描钱包地址二维码，请在下个对话中允此权限。</string><![CDATA[
        
-       
-       
-       ]]><!--/QR Code-->
+    <string name="camera_permission_scan">这个应用需要相机权限来扫描钱包地址二维码，请在下个对话中允此权限。</string><!--/QR Code-->
 
-       <!--Address--><![CDATA[
-       
-       ]]>
+       <!--Address-->
     <string name="address_copy_text">地址已复制到剪贴板</string>
-       <string name="your_address">您的地址</string><![CDATA[
        
-       ]]>
+    <string name="your_address">您的地址</string>
     <string name="generate_new_address">生成新地址</string>
-       <string name="receive_fund_privacy_info">每次请求支付都会生成一个新地址以保护您的隐私。</string><![CDATA[
        
-       
-       
-       ]]><string name="invalid_address">无效地址。</string><![CDATA[
-       
-       
-       
-       ]]><!--/Address-->
+    <string name="receive_fund_privacy_info">每次请求支付都会生成一个新地址以保护您的隐私。</string>
+    <string name="invalid_address">无效地址。</string><!--/Address-->
 
-       <!--Preference--><![CDATA[
+       <!--Preference-->
+    <string name="unconfirmed_funds">发送未确认资金</string>
+    <string name="logging_level">日志级别</string>
+    <string name="check_wallets_log">钱包日志</string>
        
-       
-       
-       ]]><string name="unconfirmed_funds">发送未确认资金</string><![CDATA[
-       
-       ]]><string name="logging_level">日志级别</string><![CDATA[
-       
-       
-       
-       ]]><string name="check_wallets_log">钱包日志</string><![CDATA[
-       
-       
-       
-       
-       ]]><string name="currency_conversion">货币转换</string><![CDATA[
-       
-       ]]><string name="user_agent_summary">用来获取交易费率。</string><![CDATA[
-       
-       
-       
+    <string name="currency_conversion">货币转换</string>
+    <string name="user_agent_summary">用来获取交易费率。</string>
 
        
-
-       ]]>
     <string-array name="currency_conversion">
-           <item>None</item>
-           <item>USD (bittrex)</item>
-       </string-array>
+               
+        <item>None</item>
+               
+        <item>USD (bittrex)</item>
+           
+    </string-array>
        <!--/Preference-->
 
-       <!-- Overview Fragment --><![CDATA[
-       
-       
-       
-       ]]><!--/ Overview Fragment -->
+       <!-- Overview Fragment --><!--/ Overview Fragment -->
 
        <!--History Fragment -->
-       <string name="sent">发送</string><![CDATA[
        
-       ]]><string name="received">已接收</string><![CDATA[
-       
-       
-       
-       ]]><!--/History Fragment -->
+    <string name="sent">发送</string>
+    <string name="received">已接收</string><!--/History Fragment -->
 
        <!--Error Messages-->
-       <string name="not_enough_funds">资金不足。</string>
-       <string name="empty_seed">密钥种子空白</string>
-       <string name="not_connected">未连接到Decred网络</string>
-       <string name="passphrase_required">缺少私人密码</string>
-       <string name="wallet_not_loaded">钱包未加载</string><![CDATA[
        
+    <string name="not_enough_funds">资金不足。</string>
        
-       ]]><string name="err_no_peers">由于缺少连接节点Decred网络不可达。</string><![CDATA[
+    <string name="empty_seed">密钥种子空白</string>
        
-       ]]><string name="not_enought_funds_synced">资金不足或未连接网络</string><![CDATA[
+    <string name="not_connected">未连接到Decred网络</string>
        
+    <string name="passphrase_required">缺少私人密码</string>
        
-       ]]><!--/Error Messages-->
+    <string name="wallet_not_loaded">钱包未加载</string>
+       
+    <string name="err_no_peers">由于缺少连接节点Decred网络不可达。</string>
+    <string name="not_enought_funds_synced">资金不足或未连接网络</string>
+       <!--/Error Messages-->
 
        <!--Security Fragment-->
-       <string name="sign_message">签署消息</string><![CDATA[
        
-       ]]><string name="message">消息</string><![CDATA[
+    <string name="sign_message">签署消息</string>
+    <string name="message">消息</string>
        
-       
-       ]]>
     <string name="valid_signature">这个签名可以验证这个消息和地址。</string>
-       <string name="invalid_signature">这个签名不能验证这个消息和地址。</string>
-       <string name="sign_message_description">此功能可以验证一个地址的合法性，签名消息以证明地址的所有权，和验证签名。</string>
+       
+    <string name="invalid_signature">这个签名不能验证这个消息和地址。</string>
+       
+    <string name="sign_message_description">此功能可以验证一个地址的合法性，签名消息以证明地址的所有权，和验证签名。</string>
        <!--/Security Fragment-->
 
-       <!--Send Fragment--><![CDATA[
+       <!--Send Fragment-->
+    <string name="_0_bytes">0 bytes</string>
        
-       
-       
-       
-       
-       
-       
-       ]]><string name="_0_bytes">0 bytes</string><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><string name="fee">手续费</string><![CDATA[
-       
-       
-       
-       
-       
-       ]]>
+    <string name="fee">手续费</string>
     <string name="send_to_account">发送到账户</string>
-       <string name="send_to_address">发送到地址</string><![CDATA[
        
-       
-       
-       ]]><!--/Send Fragment-->
+    <string name="send_to_address">发送到地址</string><!--/Send Fragment-->
 
-       <!--Transaction Details View--><![CDATA[
-       
-       
-       
-       
-       
-       
-       
-       
-       ]]><!--/Transaction Details View-->
+       <!--Transaction Details View-->
+       <!--/Transaction Details View-->
 
        <!--Confirm Transaction Dialog-->
-       <string name="toConfirmEnterYourPassword">确认输入正确密码:</string>
-       <string name="to">到</string><![CDATA[
        
+    <string name="toConfirmEnterYourPassword">确认输入正确密码:</string>
        
-       ]]><!--/Confirm Transaction Dialog-->
+    <string name="to">到</string>
+       <!--/Confirm Transaction Dialog-->
 
-       <!--Security--><![CDATA[
+       <!--Security-->
        
+    <string name="create_spending_pin">创建支付PIN码</string>
+    <string name="mismatch_passcode">PIN码不匹配，请重试。</string>
+    <string name="mismatch_password">密码不匹配</string>
        
-       ]]><string name="create_spending_pin">创建支付PIN码</string><![CDATA[
-       
-       ]]><string name="mismatch_passcode">PIN码不匹配，请重试。</string><![CDATA[
-       
-       ]]><string name="mismatch_password">密码不匹配</string><![CDATA[
-       
-       
-       ]]>
     <string name="password">密码</string>
-       <string name="enter_spending_pin">输入支付PIN码</string><![CDATA[
        
+    <string name="enter_spending_pin">输入支付PIN码</string>
        
-       ]]>
     <string name="enter_startup_pin">输入启动PIN码</string>
-       <string name="create_startup_pin">创建启动PIN码</string><![CDATA[
        
-       ]]>
+    <string name="create_startup_pin">创建启动PIN码</string>
     <string name="create_startup_password">创建启动密码</string>
-       <string name="change_spending_pin_password">更改支付PIN码/密码</string><![CDATA[
        
-       
-       
-       
-       
-       
-       
-       ]]><string name="startup_pin_password">启动PIN码或密码</string><![CDATA[
-       
-       ]]><string name="change_startup_pin_password">更改启动PIN码或密码</string><![CDATA[
-       
-       
-       
-       ]]><!--/Security-->
+    <string name="change_spending_pin_password">更改支付PIN码/密码</string>
+    <string name="startup_pin_password">启动PIN码或密码</string>
+    <string name="change_startup_pin_password">更改启动PIN码或密码</string><!--/Security-->
 
-       <!--Crash Report--><![CDATA[
-       
-       
-       ]]>
+       <!--Crash Report-->
     <string name="dont_send">不发送</string>
-       <string name="send_report">发送报告</string>
-       <string name="app_crashed">应用程序意外关闭</string>
-       <string name="crash_report_copied">已成功复制意外关闭报告</string>
-       <string name="hide_report">隐藏报告</string>
-       <string name="view_report">查看报告</string>
+       
+    <string name="send_report">发送报告</string>
+       
+    <string name="app_crashed">应用程序意外关闭</string>
+       
+    <string name="crash_report_copied">已成功复制意外关闭报告</string>
+       
+    <string name="hide_report">隐藏报告</string>
+       
+    <string name="view_report">查看报告</string>
        <!--/Crash Report-->
 
-       <string name="wifi_data_sync_title">未连接WiFi时同步</string><![CDATA[
        
-       ]]><string name="always">总是</string><![CDATA[
-       
-       ]]>
+    <string name="wifi_data_sync_title">未连接WiFi时同步</string>
+    <string name="always">总是</string>
     <string name="wifi_sync_notice">是否继续同步？</string>
-       <string name="not_connected_to_wifi">未连接WiFi。</string><![CDATA[
        
-]]>
+    <string name="not_connected_to_wifi">未连接WiFi。</string>
+       
+
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -428,7 +428,7 @@
     <string name="clear">Clear</string>
     <string name="valid_address">Valid address</string>
     <string name="external_valid_address">NOT owned by this wallet</string>
-    <string name="internal_valid_address">Owned by this wallet</string>
+    <string name="internal_valid_address">Owned by %1$s</string>
     <string name="address">Address</string>
     <string name="sign_message_instruction">Enter an address and message to sign:</string>
     <string name="signature_copied">Signature copied</string>
@@ -485,5 +485,7 @@
     <string name="step_1_2">Step 1/2</string>
     <string name="your_33_word_seed_phrase">Your 33-word seed phrase</string>
     <string name="i_have_wrote_down_all_33_words">I have wrote down all 33 words</string>
+    <string name="security_tools">Security Tools</string>
+    <string name="security_tools_message">Various tools that help in different aspects of crypto currency security will be located here.</string>
 
 </resources>


### PR DESCRIPTION
Validate addresses activity was moved from Wallets page to security tools since address validation returns the same result for every wallet. Addresses owned by any wallet in the app also shows the wallet name when validated.  

<img src="https://user-images.githubusercontent.com/19960200/71457152-f9f22980-279c-11ea-8d4a-87ee9403e4ee.png" height="500">
