### PR TITLE
Modify display error when creating wallet and wallet is online

### DIFF
--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -94,13 +94,8 @@ class WalletsFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.add_new_wallet -> {
-                if (multiWallet.isSyncing) {
+                if (multiWallet.isSyncing || multiWallet.isSynced) {
                     SnackBar.showError(context!!, R.string.cancel_sync_create_wallet)
-                    return false
-                }
-
-                if (multiWallet.isSynced) {
-                    SnackBar.showError(context!!, R.string.error_create_wallet_while_online)
                     return false
                 }
 

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -94,8 +94,13 @@ class WalletsFragment : BaseFragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.add_new_wallet -> {
-                if (multiWallet.isSyncing || multiWallet.isSynced) {
+                if (multiWallet.isSyncing) {
                     SnackBar.showError(context!!, R.string.cancel_sync_create_wallet)
+                    return false
+                }
+
+                if (multiWallet.isSynced) {
+                    SnackBar.showError(context!!, R.string.error_create_wallet_while_online)
                     return false
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
     <string name="got_it">Got It</string>
     <string name="tap_to_copy">(Tap to copy)</string>
     <string name="cancel_sync_create_wallet">Disconnect before creating wallet</string>
-    <string name="cancel_sync_delete_wallet">Cannot delete wallet while sync is in progress</string>
+    <string name="cancel_sync_delete_wallet">Disconnect before creating wallet</string>
     <string name="wallet_created">Wallet created</string>
     <string name="amount">Amount</string>
     <string name="processing_time">Processing time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@
     <string name="tap_to_copy">(Tap to copy)</string>
     <string name="cancel_sync_create_wallet">Cannot create wallet while sync is in progress</string>
     <string name="cancel_sync_delete_wallet">Cannot delete wallet while sync is in progress</string>
+    <string name="error_create_wallet_while_online">Cannot create a new wallet while wallet is online</string>
     <string name="wallet_created">Wallet created</string>
     <string name="amount">Amount</string>
     <string name="processing_time">Processing time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,9 +374,8 @@
     <string name="decred_qr_address_prefix">decred:%1$s</string>
     <string name="got_it">Got It</string>
     <string name="tap_to_copy">(Tap to copy)</string>
-    <string name="cancel_sync_create_wallet">Cannot create wallet while sync is in progress</string>
+    <string name="cancel_sync_create_wallet">Disconnect before creating wallet</string>
     <string name="cancel_sync_delete_wallet">Cannot delete wallet while sync is in progress</string>
-    <string name="error_create_wallet_while_online">Cannot create a new wallet while wallet is online</string>
     <string name="wallet_created">Wallet created</string>
     <string name="amount">Amount</string>
     <string name="processing_time">Processing time</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
     <string name="got_it">Got It</string>
     <string name="tap_to_copy">(Tap to copy)</string>
     <string name="cancel_sync_create_wallet">Disconnect before creating wallet</string>
-    <string name="cancel_sync_delete_wallet">Disconnect before creating wallet</string>
+    <string name="cancel_sync_delete_wallet">Disconnect before deleting wallet</string>
     <string name="wallet_created">Wallet created</string>
     <string name="amount">Amount</string>
     <string name="processing_time">Processing time</string>


### PR DESCRIPTION
This PR Modifies the displayed message when creating a new wallet and there is a wallet that is currently online. Before it says "Cannot create wallet while sync is in progress" even though the wallet is done syncing. This PR close [issue 427](https://github.com/decred/dcrandroid/issues/427)

Before screen.
![Screenshot from 2020-02-15 11-10-12](https://user-images.githubusercontent.com/4796738/74660433-69c9d280-5196-11ea-8733-3960f3425f44.png)

After Screen.
![Screenshot from 2020-02-17 14-55-42](https://user-images.githubusercontent.com/4796738/74660460-74846780-5196-11ea-8e47-926429d5da7c.png)
