### PR TITLE
security: show an error if passcode/password is incorrect

### DIFF
--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -153,16 +153,18 @@ class WalletSettings : BaseActivity() {
                 } catch (e: Exception) {
                     e.printStackTrace()
 
-                    val err = if (wallet.privatePassphraseType == Dcrlibwallet.PassphraseTypePin) {
-                        R.string.invalid_pin
-                    } else {
-                        R.string.invalid_password
-                    }
-
-                    withContext(Dispatchers.Main) {
+                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
+                        if (dialog is PinPromptDialog) {
+                            dialog.setProcessing(false)
+                            dialog.showError()
+                        } else if (dialog is PasswordPromptDialog) {
+                            dialog.setProcessing(false)
+                            dialog.showError()
+                        }
+                    }else{
+                        Dcrlibwallet.log(e.message)
                         dialog?.dismiss()
-
-                        SnackBar.showError(this@WalletSettings, err)
+                        SnackBar.showError(this@WalletSettings, R.string.check_log_error)
                     }
                 }
             }

--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -132,6 +132,8 @@ class WalletSettings : BaseActivity() {
     }
 
     private fun setupFingerprint() {
+        val op = this.javaClass.name + ".setupFingerprint"
+
         val title = PassPromptTitle(R.string.spending_password, R.string.enter_spending_pin)
         PassPromptUtil(this, walletID, title, false) { dialog, pass ->
 
@@ -162,7 +164,7 @@ class WalletSettings : BaseActivity() {
                             dialog.showError()
                         }
                     }else{
-                        Dcrlibwallet.log(e.message)
+                        Dcrlibwallet.logT(op, e.message)
                         dialog?.dismiss()
                         SnackBar.showError(this@WalletSettings, R.string.check_log_error)
                     }

--- a/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
@@ -58,7 +58,7 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
             if (newValue) {
                 enableStartupFingerprint()
             } else {
-                // clear passphrase from keystore
+                // clear passphrase from keystore by saving an empty passphrase
                 BiometricUtils.saveToKeystore(this@SettingsActivity, "", Constants.STARTUP_PASSPHRASE)
             }
 
@@ -145,18 +145,18 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
                 } catch (e: java.lang.Exception) {
                     e.printStackTrace()
 
-                    if (dialog is PinPromptDialog) {
-                        dialog.setProcessing(false)
-                    } else if (dialog is PasswordPromptDialog) {
-                        dialog.setProcessing(false)
-                    }
-
-                    if (e.message != Dcrlibwallet.ErrInvalidPassphrase) {
-                        val errMessage = when (dialog) {
-                            is PinPromptDialog -> R.string.invalid_pin
-                            else -> R.string.invalid_password
+                    if (e.message == Dcrlibwallet.ErrInvalidPassphrase) {
+                        if (dialog is PinPromptDialog) {
+                            dialog.setProcessing(false)
+                            dialog.showError()
+                        } else if (dialog is PasswordPromptDialog) {
+                            dialog.setProcessing(false)
+                            dialog.showError()
                         }
-                        SnackBar.showError(this@SettingsActivity, errMessage)
+                    }else{
+                        Dcrlibwallet.log(e.message)
+                        dialog?.dismiss()
+                        SnackBar.showError(this@SettingsActivity, R.string.check_log_error)
                     }
 
                     return@launch

--- a/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SettingsActivity.kt
@@ -126,6 +126,8 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
     }
 
     private fun enableStartupFingerprint() {
+        val op = this.javaClass.name + ".enableStartupFingerprint"
+
         val title = PassPromptTitle(R.string.enter_startup_password, R.string.enter_startup_pin)
         PassPromptUtil(this@SettingsActivity, null, title, false) { dialog, passphrase ->
 
@@ -154,7 +156,7 @@ class SettingsActivity : BaseActivity(), ViewTreeObserver.OnScrollChangedListene
                             dialog.showError()
                         }
                     }else{
-                        Dcrlibwallet.log(e.message)
+                        Dcrlibwallet.logT(op, e.message)
                         dialog?.dismiss()
                         SnackBar.showError(this@SettingsActivity, R.string.check_log_error)
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="wallet_not_loaded">Wallet Not Loaded</string>
     <string name="err_no_peers">Decred network is unreachable due to a lack of peers.</string>
     <string name="not_enough_funds_synced">Not enough funds (or not connected).</string>
+    <string name="check_log_error">Error occurred, check wallets log for details</string>
     <!--/Error Messages-->
 
     <!--Security Fragment-->


### PR DESCRIPTION
Passcode & password dialogs in settings do not show an error if the user enters an incorrect passphrase when enabling fingerprint. This changes that by showing invalid passphrase error on the passcode/password dialog and lets the user retry after a few seconds.
Closes #434 
<img src="https://user-images.githubusercontent.com/19960200/76431943-926a7400-63b2-11ea-8e7a-8b8015a7ddd6.gif" height="500">