### PR TITLE
Add wallet badge to the transaction details UI

### DIFF
--- a/app/src/main/java/com/dcrandroid/data/Transaction.kt
+++ b/app/src/main/java/com/dcrandroid/data/Transaction.kt
@@ -104,7 +104,7 @@ class Transaction : Serializable {
         var amount: Long = 0
         @SerializedName("account_name")
         var accountName: String? = null
-        @SerializedName("previous_account")
+        @SerializedName("account_number")
         var accountNumber: Int? = null
         @SerializedName("previous_outpoint")
         var previousOutpoint: String? = null
@@ -113,7 +113,7 @@ class Transaction : Serializable {
     class TransactionOutput : Serializable {
         @SerializedName("index")
         var index: Int = 0
-        @SerializedName("previous_account")
+        @SerializedName("account_number")
         var account: Int = 0
         @SerializedName("account_name")
         var accountName: String? = null

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/DropdownAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/DropdownAdapter.kt
@@ -11,9 +11,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.dcrandroid.R
+import com.dcrandroid.extensions.show
 import kotlinx.android.synthetic.main.input_output_row.view.*
 
-data class DropDownItem(val amount: String, val address: String)
+data class DropDownItem(val amount: String, val address: String, val badge: String)
 
 class DropdownAdapter(private val items: Array<DropDownItem>) : RecyclerView.Adapter<DropdownAdapter.ViewHolder>() {
 
@@ -31,6 +32,10 @@ class DropdownAdapter(private val items: Array<DropDownItem>) : RecyclerView.Ada
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.itemView.amount.text = items[position].amount
         holder.itemView.address.text = items[position].address
+        if(items[position].badge.isNotBlank()) {
+            holder.itemView.badge.text = items[position].badge
+            holder.itemView.badge.show()
+        }
 
         holder.itemView.address.setOnClickListener {
             addressTapped(position)

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -20,6 +20,7 @@ import com.dcrandroid.data.Constants
 import com.dcrandroid.data.Transaction
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
 import com.dcrandroid.dialog.InfoDialog
+import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.extensions.show
 import com.dcrandroid.extensions.toggleVisibility
 import com.dcrandroid.util.CoinFormat
@@ -81,6 +82,9 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                         tx_source_row.show()
                         tx_details_source.text = getSourceAccount()
 
+                        tx_source_wallet_badge.text = multiWallet.openedWalletsList()[0].name
+                        tx_source_wallet_badge.show()
+
                         tx_dest_row.show()
                         tx_details_dest.apply {
                             text = getDestinationAddress()
@@ -97,6 +101,9 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                         tx_dest_label.setText(R.string.to_account)
                         tx_details_dest.text = getReceiveAccount()
                         tx_details_dest.setTextColor(resources.getColor(R.color.darkBlueTextColor))
+
+                        tx_dest_wallet_badge.text = multiWallet.openedWalletsList()[0].name
+                        tx_dest_wallet_badge.show()
 
                         toolbar_title.setText(R.string.received)
                     }
@@ -144,7 +151,11 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         val inputs = ArrayList<DropDownItem>()
         for (input in transaction.inputs!!) {
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(input.amount), input.accountName)
-            inputs.add(DropDownItem(amount, input.previousOutpoint!!))
+            var inputBadge = ""
+            if (input.accountName != Constants.EXTERNAL){
+                inputBadge = multiWallet.openedWalletsList()[0].name
+            }
+            inputs.add(DropDownItem(amount, input.previousOutpoint!!, inputBadge))
         }
 
         InputOutputDropdown(input_dropdown_layout, inputs.toTypedArray(), top_bar)
@@ -152,7 +163,11 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         val outputs = ArrayList<DropDownItem>()
         for (output in transaction.outputs!!) {
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(output.amount), output.accountName)
-            outputs.add(DropDownItem(amount, output.address!!))
+            var outputBadge = ""
+            if (output.accountName != Constants.EXTERNAL){
+                outputBadge = multiWallet.openedWalletsList()[0].name
+            }
+            outputs.add(DropDownItem(amount, output.address!!, outputBadge))
         }
 
         InputOutputDropdown(output_dropdown_layout, outputs.toTypedArray(), isInput = false, toastAnchor = top_bar)

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -82,7 +82,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                         tx_source_row.show()
                         tx_details_source.text = getSourceAccount()
 
-                        tx_source_wallet_badge.text = multiWallet.openedWalletsList()[0].name
+                        tx_source_wallet_badge.text = multiWallet.walletWithID(transaction.walletID).name
                         tx_source_wallet_badge.show()
 
                         tx_dest_row.show()
@@ -102,7 +102,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
                         tx_details_dest.text = getReceiveAccount()
                         tx_details_dest.setTextColor(resources.getColor(R.color.darkBlueTextColor))
 
-                        tx_dest_wallet_badge.text = multiWallet.openedWalletsList()[0].name
+                        tx_dest_wallet_badge.text = multiWallet.walletWithID(transaction.walletID).name
                         tx_dest_wallet_badge.show()
 
                         toolbar_title.setText(R.string.received)
@@ -129,7 +129,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
     private fun getSourceAccount(): String? {
         for (input in transaction.inputs!!) {
-            if (input.accountName != Constants.EXTERNAL) {
+            if (input.accountName != null) {
                 return input.accountName
             }
         }
@@ -153,7 +153,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(input.amount), input.accountName)
             var inputBadge = ""
             if (input.accountName != Constants.EXTERNAL){
-                inputBadge = multiWallet.openedWalletsList()[0].name
+                inputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             inputs.add(DropDownItem(amount, input.previousOutpoint!!, inputBadge))
         }
@@ -165,7 +165,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(output.amount), output.accountName)
             var outputBadge = ""
             if (output.accountName != Constants.EXTERNAL){
-                outputBadge = multiWallet.openedWalletsList()[0].name
+                outputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             outputs.add(DropDownItem(amount, output.address!!, outputBadge))
         }

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -120,7 +120,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
     // returns first external output address if any
     private fun getDestinationAddress(): String? {
         for (output in transaction.outputs!!) {
-            if (output.accountName == Constants.EXTERNAL) {
+            if (output.account != null && output.account != -1) {
                 return output.address
             }
         }
@@ -129,7 +129,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
 
     private fun getSourceAccount(): String? {
         for (input in transaction.inputs!!) {
-            if (input.accountName != null) {
+            if (input.accountNumber != null && input.accountNumber != -1) {
                 return input.accountName
             }
         }
@@ -140,7 +140,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
     // returns first internal output address if any
     private fun getReceiveAccount(): String? {
         for (output in transaction.outputs!!) {
-            if (output.accountName != Constants.EXTERNAL) {
+            if (output.account != null && output.account != -1) {
                 return output.accountName
             }
         }
@@ -152,7 +152,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         for (input in transaction.inputs!!) {
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(input.amount), input.accountName)
             var inputBadge = ""
-            if (input.accountName != Constants.EXTERNAL){
+            if (input.accountNumber != null && input.accountNumber != -1){
                 inputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             inputs.add(DropDownItem(amount, input.previousOutpoint!!, inputBadge))
@@ -164,7 +164,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         for (output in transaction.outputs!!) {
             val amount = getString(R.string.tx_details_account, Utils.formatDecredWithComma(output.amount), output.accountName)
             var outputBadge = ""
-            if (output.accountName != Constants.EXTERNAL){
+            if (output.account != null && output.account != -1){
                 outputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             outputs.add(DropDownItem(amount, output.address!!, outputBadge))

--- a/app/src/main/res/layout/input_output_row.xml
+++ b/app/src/main/res/layout/input_output_row.xml
@@ -7,6 +7,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -14,14 +15,39 @@
     android:padding="@dimen/margin_padding_size_16"
     android:layout_marginBottom="@dimen/margin_padding_size_8">
 
-    <TextView
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/amount"
-        tools:text="0.67320257 DCR (external)"
-        android:textColor="@color/darkBlueTextColor"
-        android:textSize="@dimen/edit_text_size_16"
-        android:fontFamily="@font/source_sans_pro" />
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/amount"
+            tools:text="0.67320257 DCR (external)"
+            android:textColor="@color/darkBlueTextColor"
+            android:textSize="@dimen/edit_text_size_16"
+            android:fontFamily="@font/source_sans_pro" />
+
+
+        <TextView
+            android:id="@+id/badge"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/margin_padding_size_4"
+            android:background="@color/grayBackgroundLightColor"
+            android:includeFontPadding="false"
+            android:paddingTop="@dimen/margin_padding_size_2"
+            android:paddingBottom="@dimen/margin_padding_size_2"
+            android:paddingLeft="@dimen/margin_padding_size_4"
+            android:paddingRight="@dimen/margin_padding_size_4"
+            android:textColor="@color/lightGrayTextColor"
+            android:textSize="@dimen/edit_text_size_12"
+            android:visibility="gone"
+            app:fontFamily="@font/source_sans_pro_regular"
+            tools:text="Wallet 2" />
+
+    </LinearLayout>
 
     <TextView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/input_output_row.xml
+++ b/app/src/main/res/layout/input_output_row.xml
@@ -18,6 +18,7 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
 
         <TextView
@@ -27,14 +28,14 @@
             tools:text="0.67320257 DCR (external)"
             android:textColor="@color/darkBlueTextColor"
             android:textSize="@dimen/edit_text_size_16"
+            android:includeFontPadding="false"
             android:fontFamily="@font/source_sans_pro" />
-
 
         <TextView
             android:id="@+id/badge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/margin_padding_size_4"
+            android:layout_marginStart="@dimen/margin_padding_size_4"
             android:background="@color/grayBackgroundLightColor"
             android:includeFontPadding="false"
             android:paddingTop="@dimen/margin_padding_size_2"

--- a/app/src/main/res/layout/transaction_details.xml
+++ b/app/src/main/res/layout/transaction_details.xml
@@ -175,7 +175,7 @@
                         tools:visibility="visible"
                         android:orientation="horizontal">
 
-                        <TextView
+                       <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/from_account"
@@ -183,16 +183,46 @@
                             android:textColor="#596d81"
                             app:fontFamily="@font/source_sans_pro" />
 
-                        <TextView
-                            android:layout_width="match_parent"
+                        <!-- Adding for badge -->
+                        <LinearLayout
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:id="@+id/tx_details_source"
-                            android:gravity="end"
-                            tools:text="Default"
-                            android:textSize="@dimen/edit_text_size_16"
-                            android:textColor="@color/darkBlueTextColor"
-                            app:fontFamily="@font/source_sans_pro"
-                            android:layout_marginStart="@dimen/margin_padding_size_56" />
+                            android:orientation="horizontal">
+
+                            <View
+                                android:layout_width="0dp"
+                                android:layout_height="0dp"
+                                android:layout_weight="1" />
+
+                            <TextView
+                                android:id="@+id/tx_source_wallet_badge"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:background="@color/colorBackground"
+                                android:includeFontPadding="false"
+                                android:paddingTop="@dimen/margin_padding_size_2"
+                                android:paddingBottom="@dimen/margin_padding_size_2"
+                                android:paddingLeft="@dimen/margin_padding_size_4"
+                                android:paddingRight="@dimen/margin_padding_size_4"
+                                android:layout_marginRight="@dimen/margin_padding_size_4"
+                                android:textColor="@color/lightGrayTextColor"
+                                android:textSize="@dimen/edit_text_size_12"
+                                android:visibility="gone"
+                                app:fontFamily="@font/source_sans_pro_regular"
+                                tools:text="Wallet 2" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:id="@+id/tx_details_source"
+                                android:gravity="end"
+                                tools:text="Default"
+                                android:textSize="@dimen/edit_text_size_18"
+                                android:textColor="@color/darkBlueTextColor"
+                                app:fontFamily="@font/source_sans_pro"
+                                android:includeFontPadding="false" />
+
+                        </LinearLayout>
 
                     </LinearLayout>
 
@@ -214,18 +244,46 @@
                             android:textColor="#596d81"
                             app:fontFamily="@font/source_sans_pro" />
 
-                        <TextView
-                            android:layout_width="match_parent"
+                        <LinearLayout
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:singleLine="true"
-                            android:id="@+id/tx_details_dest"
-                            android:gravity="end"
-                            tools:text="TsR3Hwq4AAmhFreyxazD8VB3nmBgp9j7LG5"
-                            android:ellipsize="middle"
-                            android:textSize="@dimen/edit_text_size_16"
-                            android:textColor="@color/blue"
-                            app:fontFamily="@font/source_sans_pro"
-                            android:layout_marginStart="@dimen/margin_padding_size_56" />
+                            android:orientation="horizontal">
+
+                            <View
+                                android:layout_width="0dp"
+                                android:layout_height="0dp"
+                                android:layout_weight="1" />
+
+                            <TextView
+                                android:id="@+id/tx_dest_wallet_badge"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:background="@color/colorBackground"
+                                android:includeFontPadding="false"
+                                android:paddingTop="@dimen/margin_padding_size_2"
+                                android:paddingBottom="@dimen/margin_padding_size_2"
+                                android:paddingLeft="@dimen/margin_padding_size_4"
+                                android:paddingRight="@dimen/margin_padding_size_4"
+                                android:layout_marginRight="@dimen/margin_padding_size_4"
+                                android:textColor="@color/lightGrayTextColor"
+                                android:textSize="@dimen/edit_text_size_12"
+                                android:visibility="gone"
+                                app:fontFamily="@font/source_sans_pro_regular"
+                                tools:text="Wallet 2" />
+
+                            <TextView
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:singleLine="true"
+                                android:id="@+id/tx_details_dest"
+                                android:gravity="end"
+                                tools:text="TsR3Hwq4AAmhFreyxazD8VB3nmBgp9j7LG5"
+                                android:ellipsize="middle"
+                                android:textSize="@dimen/edit_text_size_16"
+                                android:textColor="@color/blue"
+                                app:fontFamily="@font/source_sans_pro" />
+
+                        </LinearLayout>
 
                     </LinearLayout>
 

--- a/app/src/main/res/layout/transaction_details.xml
+++ b/app/src/main/res/layout/transaction_details.xml
@@ -183,16 +183,12 @@
                             android:textColor="#596d81"
                             app:fontFamily="@font/source_sans_pro" />
 
-                        <!-- Adding for badge -->
                         <LinearLayout
-                            android:layout_width="wrap_content"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="end|center_vertical"
                             android:orientation="horizontal">
-
-                            <View
-                                android:layout_width="0dp"
-                                android:layout_height="0dp"
-                                android:layout_weight="1" />
 
                             <TextView
                                 android:id="@+id/tx_source_wallet_badge"
@@ -204,7 +200,7 @@
                                 android:paddingBottom="@dimen/margin_padding_size_2"
                                 android:paddingLeft="@dimen/margin_padding_size_4"
                                 android:paddingRight="@dimen/margin_padding_size_4"
-                                android:layout_marginRight="@dimen/margin_padding_size_4"
+                                android:layout_marginEnd="@dimen/margin_padding_size_4"
                                 android:textColor="@color/lightGrayTextColor"
                                 android:textSize="@dimen/edit_text_size_12"
                                 android:visibility="gone"
@@ -245,14 +241,11 @@
                             app:fontFamily="@font/source_sans_pro" />
 
                         <LinearLayout
-                            android:layout_width="wrap_content"
+                            android:layout_width="0dp"
                             android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:gravity="end|center_vertical"
                             android:orientation="horizontal">
-
-                            <View
-                                android:layout_width="0dp"
-                                android:layout_height="0dp"
-                                android:layout_weight="1" />
 
                             <TextView
                                 android:id="@+id/tx_dest_wallet_badge"
@@ -264,7 +257,7 @@
                                 android:paddingBottom="@dimen/margin_padding_size_2"
                                 android:paddingLeft="@dimen/margin_padding_size_4"
                                 android:paddingRight="@dimen/margin_padding_size_4"
-                                android:layout_marginRight="@dimen/margin_padding_size_4"
+                                android:layout_marginEnd="@dimen/margin_padding_size_4"
                                 android:textColor="@color/lightGrayTextColor"
                                 android:textSize="@dimen/edit_text_size_12"
                                 android:visibility="gone"
@@ -272,7 +265,7 @@
                                 tools:text="Wallet 2" />
 
                             <TextView
-                                android:layout_width="match_parent"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:singleLine="true"
                                 android:id="@+id/tx_details_dest"


### PR DESCRIPTION
This pull request add the wallet badge to the transaction details UI.

<img src="https://user-images.githubusercontent.com/4796738/77173569-fd593080-6abf-11ea-9ebe-57ab78237972.jpeg" height="500">

<img src="https://user-images.githubusercontent.com/4796738/77173583-02b67b00-6ac0-11ea-86fa-04ac7aea02f2.jpeg" height="500">

<img src="https://user-images.githubusercontent.com/4796738/77173608-0d711000-6ac0-11ea-93e1-fe6e141a1e2d.jpeg" height="500">



