### PR TITLE
Add watch-only wallet support

### DIFF
--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -107,7 +107,11 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
         }
 
         fab_send.setOnClickListener {
-            if(multiWallet!!.isSyncing){
+
+            if (multiWallet!!.allWalletsAreWatchOnly()) { // only wallet is watch only
+                SnackBar.showError(this, R.string.watch_only_wallet_error)
+                return@setOnClickListener
+            } else if (multiWallet!!.isSyncing) {
                 SnackBar.showError(this, R.string.wait_for_sync)
                 return@setOnClickListener
             }else if (!multiWallet!!.isConnectedToDecredNetwork){

--- a/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
@@ -25,6 +25,7 @@ import com.dcrandroid.BuildConfig
 import com.dcrandroid.HomeActivity
 import com.dcrandroid.R
 import com.dcrandroid.data.Constants
+import com.dcrandroid.dialog.CreateWatchOnlyWallet
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
 import com.dcrandroid.dialog.InfoDialog
 import com.dcrandroid.extensions.hide
@@ -65,6 +66,13 @@ class SplashScreenActivity : BaseActivity() {
         ll_restore_wallet.setOnClickListener {
             val restoreIntent = Intent(this, RestoreWalletActivity::class.java)
             startActivityForResult(restoreIntent, RESTORE_WALLET_REQUEST_CODE)
+        }
+
+        ll_watch_only_wallet.setOnClickListener {
+            CreateWatchOnlyWallet {
+                SnackBar.showText(this@SplashScreenActivity, R.string.watch_only_wallet_created)
+                proceedToHomeActivity()
+            }.show(this)
         }
 
         if (BuildConfig.IS_TESTNET) {
@@ -234,7 +242,7 @@ class SplashScreenActivity : BaseActivity() {
         val objectAnimator = ObjectAnimator.ofPropertyValuesHolder(welcome_text, pvhX, pvhAlpha)
 
 
-        val bottomMargin = resources.getDimensionPixelOffset(R.dimen.margin_padding_size_180)
+        val bottomMargin = resources.getDimensionPixelOffset(R.dimen.setup_wallet_anim_margin)
         val layoutParams = bottom_bar_layout.layoutParams as LinearLayout.LayoutParams
         layoutParams.bottomMargin = -bottomMargin
         bottom_bar_layout.show()

--- a/app/src/main/java/com/dcrandroid/activities/more/SecurityTools.kt
+++ b/app/src/main/java/com/dcrandroid/activities/more/SecurityTools.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
 import com.dcrandroid.activities.security.ValidateAddress
+import com.dcrandroid.activities.security.VerifyMessage
 import com.dcrandroid.dialog.InfoDialog
 import com.dcrandroid.fragments.more.ListAdapter
 import com.dcrandroid.fragments.more.ListItem
@@ -36,7 +37,9 @@ class SecurityTools : BaseActivity() {
         }
 
         val items = arrayOf(
-                ListItem(R.string.validate_addresses, R.drawable.ic_location_pin, Intent(this, ValidateAddress::class.java)))
+                ListItem(R.string.verify_message, R.drawable.ic_verify_message, Intent(this, VerifyMessage::class.java)),
+                ListItem(R.string.validate_addresses, R.drawable.ic_location_pin, Intent(this, ValidateAddress::class.java))
+        )
 
         val adapter = ListAdapter(this, items)
         security_tools_recycler_view.layoutManager = LinearLayoutManager(this)

--- a/app/src/main/java/com/dcrandroid/activities/security/SignMessage.kt
+++ b/app/src/main/java/com/dcrandroid/activities/security/SignMessage.kt
@@ -44,7 +44,7 @@ class SignMessage : BaseActivity(), View.OnClickListener {
 
 
         addressInputHelper = InputHelper(this, address_container) {
-            wallet.isAddressValid(it)
+            multiWallet!!.isAddressValid(it)
         }
         addressInputHelper.setHint(R.string.address)
         addressInputHelper.textChanged = textChanged

--- a/app/src/main/java/com/dcrandroid/activities/security/ValidateAddress.kt
+++ b/app/src/main/java/com/dcrandroid/activities/security/ValidateAddress.kt
@@ -18,7 +18,7 @@ import kotlinx.android.synthetic.main.activity_validate_address.*
 
 class ValidateAddress : BaseActivity(), View.OnClickListener {
 
-    lateinit var addressInputHelper: InputHelper
+    private lateinit var addressInputHelper: InputHelper
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,19 +66,15 @@ class ValidateAddress : BaseActivity(), View.OnClickListener {
         var titleText = R.string.invalid_address
         var subtitleText: String? = null
 
-        var foundAddress = false
+        val addressIsValid = multiWallet!!.isAddressValid(address)
+        if (addressIsValid) {
+            tv_title.setTextColor(getColor(R.color.greenTextColor))
+            tv_subtitle.show()
 
-        for (wallet in wallets) {
+            icon = R.drawable.ic_checkmark
+            titleText = R.string.valid_address
 
-            if (wallet.isAddressValid(address)) {
-                foundAddress = true
-
-                tv_title.setTextColor(getColor(R.color.greenTextColor))
-                tv_subtitle.show()
-
-                icon = R.drawable.ic_checkmark
-                titleText = R.string.valid_address
-
+            for (wallet in wallets) {
                 if (wallet.haveAddress(address)) {
                     subtitleText = getString(R.string.internal_valid_address, wallet.name)
                     tv_subtitle.setTextColor(getColor(R.color.greenLightTextColor))
@@ -91,7 +87,7 @@ class ValidateAddress : BaseActivity(), View.OnClickListener {
         }
 
         result_layout.show()
-        if (!foundAddress) {
+        if (!addressIsValid) {
             tv_title.setTextColor(getColor(R.color.colorError))
             tv_subtitle.hide()
         }

--- a/app/src/main/java/com/dcrandroid/activities/security/VerifyMessage.kt
+++ b/app/src/main/java/com/dcrandroid/activities/security/VerifyMessage.kt
@@ -11,18 +11,14 @@ import android.view.ViewTreeObserver
 import androidx.core.text.HtmlCompat
 import com.dcrandroid.R
 import com.dcrandroid.activities.BaseActivity
-import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.InfoDialog
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
 import com.dcrandroid.view.util.InputHelper
 import dcrlibwallet.Dcrlibwallet
-import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.activity_verify_message.*
 
 class VerifyMessage : BaseActivity(), ViewTreeObserver.OnScrollChangedListener {
-
-    private lateinit var wallet: Wallet
 
     lateinit var addressInputHelper: InputHelper
     lateinit var messageInputHelper: InputHelper
@@ -32,11 +28,8 @@ class VerifyMessage : BaseActivity(), ViewTreeObserver.OnScrollChangedListener {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_verify_message)
 
-        val walletID = intent.getLongExtra(Constants.WALLET_ID, -1)
-        wallet = multiWallet!!.walletWithID(walletID)
-
         addressInputHelper = InputHelper(this, address_container) {
-            wallet.isAddressValid(it)
+            multiWallet!!.isAddressValid(it)
         }.apply {
             setHint(R.string.address)
 
@@ -122,7 +115,7 @@ class VerifyMessage : BaseActivity(), ViewTreeObserver.OnScrollChangedListener {
 
             var validSignature = false
             try {
-                validSignature = wallet.verifyMessage(address, message, base64Signature)
+                validSignature = multiWallet!!.verifyMessage(address, message, base64Signature)
             } catch (e: java.lang.Exception) {
                 e.printStackTrace()
             }

--- a/app/src/main/java/com/dcrandroid/adapter/PopupMenuAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/adapter/PopupMenuAdapter.kt
@@ -54,7 +54,9 @@ class PopupMenuAdapter(private val context: Context, private val items: Array<An
         val item = items[position]
         if (item is PopupItem) {
             holder.itemView.popup_text.setText(item.title)
-            holder.itemView.popup_text.setTextColor(context.resources.getColor(item.color))
+
+            val textColor = if (item.enabled) item.color else R.color.colorDisabled
+            holder.itemView.popup_text.setTextColor(context.resources.getColor(textColor))
             holder.itemView.isEnabled = item.enabled
 
             holder.itemView.setOnClickListener {

--- a/app/src/main/java/com/dcrandroid/dialog/AccountDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/AccountDetailsDialog.kt
@@ -24,11 +24,8 @@ import kotlinx.android.synthetic.main.account_details.*
 class AccountDetailsDialog(private val ctx: Context, val walletID: Long, val account: Account,
                            val renameAccount: (newName: String) -> Exception?) : FullScreenBottomSheetDialog() {
 
-    private var wallet: Wallet? = null
+    private val wallet: Wallet = multiWallet.walletWithID(walletID)
 
-    init {
-        this.wallet = multiWallet.walletWithID(walletID)
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.account_details, container, false)
@@ -39,7 +36,10 @@ class AccountDetailsDialog(private val ctx: Context, val walletID: Long, val acc
 
         val balance = account.balance
 
-        tv_account_name.text = account.accountName
+        tv_account_name.text = if (wallet.isWatchingOnlyWallet) {
+            wallet.name
+        } else account.accountName
+
         account_details_total_balance.text = CoinFormat.format(account.totalBalance, 0.625f)
         account_details_spendable.text = CoinFormat.format(balance.spendable)
 
@@ -55,13 +55,18 @@ class AccountDetailsDialog(private val ctx: Context, val walletID: Long, val acc
 
         // properties
         account_details_number.text = account.accountNumber.toString()
-        account_details_path.text = account.hdPath
         account_details_keys.text = context!!.getString(R.string.key_count, account.externalKeyCount, account.internalKeyCount, account.importedKeyCount)
-
-        if (account.accountNumber == Int.MAX_VALUE) { // imported account
-            default_account_row.hide()
-            account_details_icon.setImageResource(R.drawable.ic_accounts_locked)
+        if (wallet.isWatchingOnlyWallet) {
             iv_rename_account.hide()
+            account_number_row.hide()
+            hd_path_row.hide()
+        } else {
+            account_details_path.text = account.hdPath
+        }
+
+        if (account.accountNumber == Int.MAX_VALUE) {
+            iv_rename_account.hide()
+            account_details_icon.setImageResource(R.drawable.ic_accounts_locked)
         }
 
         // click listeners

--- a/app/src/main/java/com/dcrandroid/dialog/AccountPickerDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/AccountPickerDialog.kt
@@ -16,12 +16,14 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.dcrandroid.R
 import com.dcrandroid.adapter.AccountPickerAdapter
 import com.dcrandroid.data.Account
+import com.dcrandroid.extensions.fullCoinWalletsList
 import com.dcrandroid.extensions.openedWalletsList
 import com.dcrandroid.extensions.walletAccounts
 import com.dcrandroid.util.WalletData
 import kotlinx.android.synthetic.main.account_picker_sheet.*
 
-class AccountPickerDialog(@StringRes val title: Int, val currentAccount: Account, val accountSelected: (account: Account) -> Unit?) : FullScreenBottomSheetDialog(),
+class AccountPickerDialog(@StringRes val title: Int, val currentAccount: Account, private val showWatchOnlyWallets: Boolean,
+                          val accountSelected: (account: Account) -> Unit?) : FullScreenBottomSheetDialog(),
         ViewTreeObserver.OnScrollChangedListener {
 
     private var layoutManager: LinearLayoutManager? = null
@@ -36,7 +38,7 @@ class AccountPickerDialog(@StringRes val title: Int, val currentAccount: Account
         account_picker_title.setText(title)
 
         val multiWallet = WalletData.multiWallet!!
-        val wallets = multiWallet.openedWalletsList()
+        val wallets = if (showWatchOnlyWallets) multiWallet.openedWalletsList() else multiWallet.fullCoinWalletsList()
 
         val items = ArrayList<Any>()
 

--- a/app/src/main/java/com/dcrandroid/dialog/DeleteWatchOnlyWallet.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/DeleteWatchOnlyWallet.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018-2019 The Decred developers
+ * Use of this source code is governed by an ISC
+ * license that can be found in the LICENSE file.
+ */
+
+package com.dcrandroid.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.dcrandroid.R
+import com.dcrandroid.extensions.hide
+import com.dcrandroid.extensions.show
+import com.dcrandroid.util.Utils
+import com.dcrandroid.view.util.InputHelper
+import dcrlibwallet.Dcrlibwallet
+import dcrlibwallet.Wallet
+import kotlinx.android.synthetic.main.delete_watch_only_wallet_sheet.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class DeleteWatchOnlyWallet(val wallet: Wallet, val walletDeleted: () -> Unit) : FullScreenBottomSheetDialog() {
+
+    private var walletNameInput: InputHelper? = null
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.delete_watch_only_wallet_sheet, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        walletNameInput = InputHelper(context!!, wallet_name) {
+            true
+        }.apply {
+            hintTextView.setText(R.string.wallet_name)
+            hideQrScanner()
+            hidePasteButton()
+        }
+
+        walletNameInput?.textChanged = {
+            btn_delete.isEnabled = walletNameInput?.validatedInput!! == wallet.name
+        }
+
+        btn_cancel.setOnClickListener {
+            dismiss()
+        }
+
+        btn_delete.setOnClickListener {
+            toggleButtons(false)
+            GlobalScope.launch(Dispatchers.Default) {
+                try {
+                    multiWallet.deleteWallet(wallet.id, null)
+                    walletDeleted()
+                } catch (e: Exception) {
+                    toggleButtons(true)
+                    withContext(Dispatchers.Main) {
+                        val op = this@DeleteWatchOnlyWallet.javaClass.name + ": createWatchOnlyWallet"
+                        Utils.showErrorDialog(this@DeleteWatchOnlyWallet.context!!, op + ": " + e.message)
+                        Dcrlibwallet.logT(op, e.message)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun toggleButtons(enable: Boolean) = GlobalScope.launch(Dispatchers.Main) {
+        isCancelable = enable
+        btn_cancel.isEnabled = enable
+        walletNameInput!!.setEnabled(enable)
+        if (enable) {
+            btn_delete.show()
+            progress_bar.hide()
+        } else {
+            btn_delete.hide()
+            progress_bar.show()
+        }
+    }
+}

--- a/app/src/main/java/com/dcrandroid/dialog/ReceiveDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/ReceiveDialog.kt
@@ -62,7 +62,7 @@ class ReceiveDialog(dismissListener: DialogInterface.OnDismissListener) : FullSc
         tv_address.setOnClickListener { copyAddress() }
         qr_image.setOnClickListener { copyAddress() }
 
-        sourceAccountSpinner = AccountCustomSpinner(activity!!.supportFragmentManager, source_account_spinner, R.string.dest_account_picker_title) {
+        sourceAccountSpinner = AccountCustomSpinner(activity!!.supportFragmentManager, source_account_spinner, true, R.string.dest_account_picker_title) {
             setAddress(it.getCurrentAddress())
             return@AccountCustomSpinner Unit
         }

--- a/app/src/main/java/com/dcrandroid/dialog/send/DestinationAddressCard.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/DestinationAddressCard.kt
@@ -24,7 +24,7 @@ class DestinationAddressCard(context: Context, val layout: LinearLayout, validat
 
     init {
         val activity = context as AppCompatActivity
-        destinationAccountSpinner = AccountCustomSpinner(activity.supportFragmentManager, layout.destination_account_spinner, R.string.dest_account_picker_title)
+        destinationAccountSpinner = AccountCustomSpinner(activity.supportFragmentManager, layout.destination_account_spinner, true, R.string.dest_account_picker_title)
         addressInputHelper = InputHelper(context, layout.destination_address_container, validateAddress)
         addressInputHelper.editText.inputType = InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
 

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -82,7 +82,7 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
         }
 
         sourceAccountSpinner = AccountCustomSpinner(activity!!.supportFragmentManager,
-                source_account_spinner, R.string.source_account_picker_title, sourceAccountChanged)
+                source_account_spinner, false, R.string.source_account_picker_title, sourceAccountChanged)
 
         destinationAddressCard = DestinationAddressCard(context!!, dest_address_card, validateAddress).apply {
             addressChanged = this@SendDialog.addressChanged
@@ -230,7 +230,7 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
     }
 
     private val validateAddress: (String) -> Boolean = {
-        sourceAccountSpinner.wallet.isAddressValid(it)
+        multiWallet.isAddressValid(it)
     }
 
     override fun onScrollChanged() {

--- a/app/src/main/java/com/dcrandroid/extensions/MultiWallet.kt
+++ b/app/src/main/java/com/dcrandroid/extensions/MultiWallet.kt
@@ -29,6 +29,14 @@ fun MultiWallet.openedWalletsList(): ArrayList<Wallet> {
     return wallets
 }
 
+fun MultiWallet.fullCoinWalletsList(): ArrayList<Wallet> {
+    return this.openedWalletsList().filter { !it.isWatchingOnlyWallet } as ArrayList<Wallet>
+}
+
+fun MultiWallet.watchOnlyWalletsList(): ArrayList<Wallet> {
+    return this.openedWalletsList().filter { it.isWatchingOnlyWallet } as ArrayList<Wallet>
+}
+
 fun MultiWallet.totalWalletBalance(): Long {
     val wallets = this.openedWalletsList()
     var totalBalance: Long = 0

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -21,6 +21,7 @@ import com.dcrandroid.adapter.PopupItem
 import com.dcrandroid.adapter.PopupUtil
 import com.dcrandroid.adapter.WalletsAdapter
 import com.dcrandroid.data.Constants
+import com.dcrandroid.dialog.CreateWatchOnlyWallet
 import com.dcrandroid.dialog.FullScreenBottomSheetDialog
 import com.dcrandroid.dialog.RequestNameDialog
 import com.dcrandroid.util.SnackBar
@@ -114,7 +115,7 @@ class WalletsFragment : BaseFragment() {
                             PopupItem(R.string.create_a_new_wallet),
                             PopupItem(R.string.import_existing_wallet),
                             PopupDivider(dividerWidth),
-                            PopupItem(R.string.import_watching_only_wallet, R.color.colorDisabled, false)
+                            PopupItem(R.string.import_watching_only_wallet)
                     )
 
                     PopupUtil.showPopup(anchorView, items) { window, index ->
@@ -143,7 +144,10 @@ class WalletsFragment : BaseFragment() {
                                 startActivityForResult(restoreIntent, RESTORE_WALLET_REQUEST_CODE)
                             }
                             3 -> {
-                                // create watching only wallet
+                                CreateWatchOnlyWallet {
+                                    SnackBar.showText(context!!, R.string.watch_only_wallet_created)
+                                    adapter.addWallet(it.id)
+                                }.show(context!!)
                             }
                         }
                     }

--- a/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/AccountCustomSpinner.kt
@@ -12,16 +12,13 @@ import androidx.fragment.app.FragmentManager
 import com.dcrandroid.data.Account
 import com.dcrandroid.data.Constants
 import com.dcrandroid.dialog.AccountPickerDialog
-import com.dcrandroid.extensions.hide
-import com.dcrandroid.extensions.openedWalletsList
-import com.dcrandroid.extensions.show
-import com.dcrandroid.extensions.walletAccounts
+import com.dcrandroid.extensions.*
 import com.dcrandroid.util.CoinFormat
 import com.dcrandroid.util.WalletData
 import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.account_custom_spinner.view.*
 
-class AccountCustomSpinner(private val fragmentManager: FragmentManager, private val spinnerLayout: View,
+class AccountCustomSpinner(private val fragmentManager: FragmentManager, private val spinnerLayout: View, private val showWatchOnlyWallets: Boolean,
                            @StringRes val pickerTitle: Int, var selectedAccountChanged: ((AccountCustomSpinner) -> Unit?)? = null) : View.OnClickListener {
 
     val context = spinnerLayout.context
@@ -49,7 +46,12 @@ class AccountCustomSpinner(private val fragmentManager: FragmentManager, private
     init {
         // Set default selected account as "default"
         // account from the first opened wallet
-        wallet = multiWallet!!.openedWalletsList()[0]
+        wallet = if (showWatchOnlyWallets) {
+            multiWallet!!.openedWalletsList()[0]
+        } else {
+            multiWallet!!.fullCoinWalletsList()[0]
+        }
+
 
         selectedAccount = Account.from(wallet.getAccount(Constants.DEF_ACCOUNT_NUMBER))
         spinnerLayout.setOnClickListener(this)
@@ -64,7 +66,7 @@ class AccountCustomSpinner(private val fragmentManager: FragmentManager, private
     }
 
     override fun onClick(v: View?) {
-        AccountPickerDialog(pickerTitle, selectedAccount!!) {
+        AccountPickerDialog(pickerTitle, selectedAccount!!, showWatchOnlyWallets) {
             selectedAccount = it
             return@AccountPickerDialog Unit
         }.show(fragmentManager, null)

--- a/app/src/main/java/com/dcrandroid/view/util/InputHelper.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/InputHelper.kt
@@ -150,6 +150,13 @@ class InputHelper(private val context: Context, private val container: View,
         container.input_layout.setBackgroundResource(backgroundResource)
     }
 
+    fun setEnabled(enabled: Boolean) {
+        editText.isEnabled = false
+        clearBtn.isEnabled = enabled
+        qrScanImageView.isEnabled
+        pasteTextView.isEnabled = enabled
+    }
+
     private fun setupButtons() {
         if (editText.text.isNotEmpty()) {
             if (!clearBtnHidden)

--- a/app/src/main/res/drawable/ic_verify_message.xml
+++ b/app/src/main/res/drawable/ic_verify_message.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="25dp"
+    android:viewportWidth="24"
+    android:viewportHeight="25">
+    <path
+        android:pathData="M3,24l18,-0.0019l0,-17.9981l-4,-4l-14,0z"
+        android:strokeWidth="1"
+        android:fillColor="#C4CBD2"
+        android:fillType="nonZero"
+        android:strokeColor="#00000000" />
+    <path
+        android:pathData="M19,20m-5,0a5,5 0,1 1,10 0a5,5 0,1 1,-10 0"
+        android:strokeWidth="1"
+        android:fillColor="#091440"
+        android:fillType="evenOdd"
+        android:strokeColor="#00000000" />
+    <path
+        android:pathData="M6,8h12v2h-12z"
+        android:strokeWidth="1"
+        android:fillColor="#091440"
+        android:fillType="evenOdd"
+        android:strokeColor="#00000000" />
+    <path
+        android:pathData="M6,12h12v2h-12z"
+        android:strokeWidth="1"
+        android:fillColor="#091440"
+        android:fillType="evenOdd"
+        android:strokeColor="#00000000" />
+    <path
+        android:pathData="M6,16h7v2h-7z"
+        android:strokeWidth="1"
+        android:fillColor="#091440"
+        android:fillType="evenOdd"
+        android:strokeColor="#00000000" />
+    <path
+        android:pathData="M16.3536,19.6464l-0.7071,0.7071l2.3536,2.3536l4.3536,-4.3536l-0.7071,-0.7071l-3.6464,3.6464z"
+        android:strokeWidth="1"
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:strokeColor="#00000000" />
+</vector>

--- a/app/src/main/res/layout/account_details.xml
+++ b/app/src/main/res/layout/account_details.xml
@@ -274,79 +274,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
-                android:id="@+id/default_account_row"
-                android:orientation="vertical">
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/grayBackgroundLightColor" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textSize="@dimen/edit_text_size_14"
-                    android:textColor="@color/darkerBlueGrayTextColor"
-                    app:fontFamily="@font/source_sans_pro"
-                    android:text="@string/settings"
-                    android:layout_marginTop="@dimen/margin_padding_size_16"
-                    android:layout_marginLeft="@dimen/margin_padding_size_16"
-                    android:layout_marginStart="@dimen/margin_padding_size_16"
-                    android:layout_marginBottom="@dimen/margin_padding_size_8"
-                    android:layout_marginRight="@dimen/margin_padding_size_16"
-                    android:layout_marginEnd="@dimen/margin_padding_size_16"
-                    />
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/margin_padding_size_16"
-                    android:orientation="horizontal"
-                    android:gravity="center_vertical"
-                    >
-
-                    <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:orientation="vertical">
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textSize="@dimen/edit_text_size_16"
-                            android:textColor="@color/darkBlueTextColor"
-                            app:fontFamily="@font/source_sans_pro"
-                            android:text="@string/default_account"
-                            android:includeFontPadding="false" />
-
-                        <TextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textSize="@dimen/edit_text_size_14"
-                            android:textColor="@color/blueGraySecondTextColor"
-                            android:includeFontPadding="false"
-                            app:fontFamily="@font/source_sans_pro"
-                            android:layout_marginTop="4dp"
-                            android:text="@string/default_account_switch_desc" />
-
-                    </LinearLayout>
-
-                    <androidx.appcompat.widget.SwitchCompat
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:theme="@style/Switch"
-                        android:id="@+id/default_account_switch"
-                        />
-
-                </LinearLayout>
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible"
                 android:id="@+id/account_details_properties"
                 android:orientation="vertical">
 
@@ -374,6 +301,7 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:id="@+id/account_number_row"
                         android:layout_marginTop="@dimen/margin_padding_size_16"
                         android:orientation="horizontal">
 
@@ -403,6 +331,7 @@
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:id="@+id/hd_path_row"
                         android:layout_marginTop="@dimen/margin_padding_size_16"
                         android:orientation="horizontal">
 

--- a/app/src/main/res/layout/activity_splash_screen.xml
+++ b/app/src/main/res/layout/activity_splash_screen.xml
@@ -137,6 +137,40 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/ll_watch_only_wallet"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/transparent_ripple_corner_8dp"
+            android:padding="@dimen/margin_padding_size_16"
+            android:layout_marginTop="@dimen/margin_padding_size_16"
+            android:layout_marginBottom="@dimen/margin_padding_size_8"
+            android:layout_marginLeft="@dimen/margin_padding_size_8"
+            android:layout_marginRight="@dimen/margin_padding_size_8"
+            android:gravity="center_vertical"
+            android:elevation="@dimen/shadow_spread"
+            android:clickable="true"
+            android:focusable="true"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                app:srcCompat="@drawable/ic_restore_wallet_24px" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/import_watching_only_wallet"
+                android:layout_marginStart="@dimen/margin_padding_size_16"
+                android:textColor="@color/blue"
+                android:textSize="@dimen/edit_text_size_18"
+                android:includeFontPadding="false"
+                app:fontFamily="@font/source_sans_pro" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_wallet_settings.xml
+++ b/app/src/main/res/layout/activity_wallet_settings.xml
@@ -87,6 +87,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/margin_padding_size_4"
+                android:id="@+id/spending_password_card"
                 android:elevation="4dp"
                 android:orientation="vertical"
                 android:paddingTop="@dimen/margin_padding_size_16"

--- a/app/src/main/res/layout/delete_watch_only_wallet_sheet.xml
+++ b/app/src/main/res/layout/delete_watch_only_wallet_sheet.xml
@@ -16,21 +16,16 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_padding_size_8"
-        android:text="@string/create_watch_only_wallet"
+        android:text="Enter wallet name"
         android:textColor="@color/darkBlueTextColor"
         android:textSize="@dimen/edit_text_size_20"
         app:fontFamily="@font/source_sans_pro_semibold" />
 
-   <include
-       android:id="@+id/wallet_name"
-       layout="@layout/custom_input"
-       android:layout_width="match_parent"
-       android:layout_height="wrap_content"
-       />
-
-   <include
-       android:id="@+id/extended_public_key"
-       layout="@layout/custom_input"/>
+    <include
+        android:id="@+id/wallet_name"
+        layout="@layout/custom_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="wrap_content"
@@ -55,19 +50,19 @@
             android:layout_marginEnd="@dimen/margin_padding_size_8" />
 
         <TextView
-            android:id="@+id/btn_import"
+            android:id="@+id/btn_delete"
             android:layout_width="83dp"
             android:layout_height="40dp"
             android:gravity="center"
             android:background="@drawable/default_app_button_bg"
             android:enabled="false"
-            android:text="@string/_import"
+            android:text="@string/delete"
             android:textColor="@color/white"
             android:textSize="@dimen/edit_text_size_16"
             android:focusable="true"
             android:clickable="true"
             app:fontFamily="@font/source_sans_pro_semibold"
-            android:includeFontPadding="false"/>
+            android:includeFontPadding="false" />
 
         <ProgressBar
             android:id="@+id/progress_bar"

--- a/app/src/main/res/layout/popup_layout.xml
+++ b/app/src/main/res/layout/popup_layout.xml
@@ -13,6 +13,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:scrollbars="vertical"
         android:id="@+id/popup_rv"
         android:paddingTop="@dimen/margin_padding_size_8"
         android:paddingBottom="@dimen/margin_padding_size_8"

--- a/app/src/main/res/layout/wallet_row.xml
+++ b/app/src/main/res/layout/wallet_row.xml
@@ -13,7 +13,7 @@
     android:layout_marginBottom="@dimen/margin_padding_size_4"
     android:layout_marginStart="@dimen/margin_padding_size_8"
     android:layout_marginEnd="@dimen/margin_padding_size_8"
-    android:background="@drawable/card_bg"
+    android:background="@color/white"
     android:elevation="4dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -36,14 +36,13 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:id="@+id/expand_icon"
+            android:layout_marginEnd="@dimen/margin_padding_size_8"
             app:srcCompat="@drawable/ic_expand02" />
 
         <ImageView
             android:layout_width="24dp"
             android:layout_height="24dp"
-            app:srcCompat="@drawable/ic_wallet"
-            android:layout_marginLeft="@dimen/margin_padding_size_8"
-            android:layout_marginStart="@dimen/margin_padding_size_8" />
+            app:srcCompat="@drawable/ic_wallet" />
 
         <LinearLayout
             android:layout_width="0dp"
@@ -51,7 +50,6 @@
             android:layout_weight="1"
             android:orientation="vertical"
             android:layout_gravity="center_vertical"
-            android:layout_marginLeft="@dimen/margin_padding_size_16"
             android:layout_marginStart="@dimen/margin_padding_size_16">
 
             <TextView
@@ -81,7 +79,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/wallet_total_balance"
-            android:layout_marginLeft="@dimen/margin_padding_size_8"
             android:layout_marginStart="@dimen/margin_padding_size_8"
             app:fontFamily="@font/source_sans_pro"
             tools:text="7.51464806 DCR"

--- a/app/src/main/res/layout/watch_only_wallet_list_header.xml
+++ b/app/src/main/res/layout/watch_only_wallet_list_header.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018-2019 The Decred developers
+  ~ Use of this source code is governed by an ISC
+  ~ license that can be found in the LICENSE file.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/card_bg_header"
+    android:elevation="@dimen/margin_padding_size_4"
+    android:layout_marginTop="@dimen/margin_padding_size_4"
+    android:layout_marginStart="@dimen/margin_padding_size_8"
+    android:layout_marginEnd="@dimen/margin_padding_size_8"
+    android:paddingStart="@dimen/margin_padding_size_16"
+    android:paddingTop="@dimen/margin_padding_size_16"
+    android:paddingEnd="@dimen/margin_padding_size_16"
+    android:paddingBottom="@dimen/margin_padding_size_8">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:includeFontPadding="false"
+        android:text="@string/watch_only_wallets"
+        android:textColor="@color/darkerBlueGrayTextColor"
+        android:textSize="@dimen/edit_text_size_14"
+        android:fontFamily="@font/source_sans_pro_regular" />
+
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -40,6 +40,7 @@
     <dimen name="margin_padding_size_128">128dp</dimen>
     <dimen name="margin_padding_size_180">180dp</dimen>
 
+    <dimen name="setup_wallet_anim_margin">256dp</dimen>
 
     <dimen name="wallets_menu_width">152dp</dimen>
     <dimen name="add_wallet_menu_width">224dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="always">Always</string>
     <string name="rename">Rename</string>
     <string name="create">Create</string>
+    <string name="_import">Import</string>
     <string name="dcr_amount">%1$s DCR</string>
     <string name="rename_wallet_sheet_title">Rename wallet</string>
     <string name="wallet_name">Wallet Name</string>
@@ -212,6 +213,7 @@
     <string name="not_enough_funds">Not enough funds.</string>
     <string name="empty_seed">Empty Seed</string>
     <string name="not_connected">Not connected to Decred network</string>
+    <string name="watch_only_wallet_error">Only wallet is watching only</string>
     <string name="passphrase_required">Private Passphrase is required</string>
     <string name="wallet_not_loaded">Wallet Not Loaded</string>
     <string name="err_no_peers">Decred network is unreachable due to a lack of peers.</string>
@@ -391,6 +393,7 @@
     <string name="cancel_sync_create_wallet">Disconnect before creating wallet</string>
     <string name="cancel_sync_delete_wallet">Disconnect before deleting wallet</string>
     <string name="wallet_created">Wallet created</string>
+    <string name="watch_only_wallet_created">Watch-only wallet imported</string>
     <string name="amount">Amount</string>
     <string name="processing_time">Processing time</string>
     <string name="fee_rate">Fee rate</string>
@@ -528,5 +531,6 @@
     <string name="month_day_format">MMMM dd</string>
     <string name="date_format">MMMM dd, yyyy</string>
     <string name="date_time_format">MMM dd, yyyy hh:mma</string>
+    <string name="watch_only_wallets">Watch-only Wallets</string>
 
 </resources>


### PR DESCRIPTION
- Moved VerifyMessage option to Security tools since it has nothing to do
  with a specific wallet.
- Hide watch-only wallets in send page source account picker
- Hide change spendable pin option for watch-only in wallet settings
- Disable SignMessage for watch-only wallets. 

 Closes #393   

| <img src="https://user-images.githubusercontent.com/19960200/82406426-7f34ee00-9a5e-11ea-92f1-0c100577d412.png" height="500">   |      <img src="https://user-images.githubusercontent.com/19960200/82406436-82c87500-9a5e-11ea-9c3a-59c54d8c8c59.png" height="500">      |
|----------|:-------------:|
