### PR TITLE
Minor fixes

### DIFF
--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -56,6 +56,7 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
 
     private var deviceWidth: Int = 0
     private var blockNotificationSound: Int = 0
+    private var lastBeepHeight: Int = -1
     private lateinit var alertSound: SoundPool
 
     private lateinit var adapter: NavigationTabsAdapter
@@ -327,9 +328,12 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
     }
 
     override fun onBlockAttached(walletID: Long, blockHeight: Int) {
-        val beepNewBlocks = multiWallet!!.readBoolConfigValueForKey(Dcrlibwallet.BeepNewBlocksConfigKey, false)
-        if (beepNewBlocks && !multiWallet!!.isSyncing) {
-            alertSound.play(blockNotificationSound, 1f, 1f, 1, 0, 1f)
+        if (lastBeepHeight == -1 || blockHeight > lastBeepHeight) {
+            lastBeepHeight = blockHeight
+            val beepNewBlocks = multiWallet!!.readBoolConfigValueForKey(Dcrlibwallet.BeepNewBlocksConfigKey, false)
+            if (beepNewBlocks && !multiWallet!!.isSyncing) {
+                alertSound.play(blockNotificationSound, 1f, 1f, 1, 0, 1f)
+            }
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/HomeActivity.kt
+++ b/app/src/main/java/com/dcrandroid/HomeActivity.kt
@@ -99,10 +99,10 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
         initNavigationTabs()
 
         fab_receive.setOnClickListener {
-            if(multiWallet!!.isSyncing){
+            if (multiWallet!!.isSyncing) {
                 SnackBar.showError(this, R.string.wait_for_sync)
                 return@setOnClickListener
-            }else if (!multiWallet!!.isConnectedToDecredNetwork){
+            } else if (!multiWallet!!.isConnectedToDecredNetwork) {
                 SnackBar.showError(this, R.string.not_connected)
                 return@setOnClickListener
             }
@@ -118,11 +118,11 @@ class HomeActivity : BaseActivity(), SyncProgressListener, TxAndBlockNotificatio
             } else if (multiWallet!!.isSyncing) {
                 SnackBar.showError(this, R.string.wait_for_sync)
                 return@setOnClickListener
-            }else if (!multiWallet!!.isConnectedToDecredNetwork){
+            } else if (!multiWallet!!.isConnectedToDecredNetwork) {
                 SnackBar.showError(this, R.string.not_connected)
                 return@setOnClickListener
             }
-            if(sendPageSheet == null){
+            if (sendPageSheet == null) {
                 sendPageSheet = SendDialog(this, bottomSheetDismissed)
             }
             sendPageSheet!!.show(this)

--- a/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/BaseActivity.kt
@@ -16,6 +16,7 @@ import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.dcrandroid.util.WalletData
 import dcrlibwallet.MultiWallet
 
@@ -32,6 +33,8 @@ open class BaseActivity : AppCompatActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val decorView = window.decorView
             decorView.systemUiVisibility = WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+        } else {
+            window.navigationBarColor = ContextCompat.getColor(this, android.R.color.black)
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/activities/LogViewer.kt
+++ b/app/src/main/java/com/dcrandroid/activities/LogViewer.kt
@@ -7,8 +7,6 @@
 package com.dcrandroid.activities
 
 import android.os.Bundle
-import android.view.Menu
-import android.view.MenuItem
 import android.view.ViewTreeObserver
 import android.widget.TextView
 import android.widget.Toast

--- a/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/RestoreWalletActivity.kt
@@ -156,7 +156,7 @@ class RestoreWalletActivity : AppCompatActivity() {
         val op = this@RestoreWalletActivity.javaClass.name + ".createWallet"
         try {
             val wallet = multiWallet!!.restoreWallet(walletName, seed, spendingKey, spendingPassType)
-            if(Locale.getDefault().language != Locale.ENGLISH.language){
+            if (Locale.getDefault().language != Locale.ENGLISH.language) {
                 wallet.renameAccount(Constants.DEF_ACCOUNT_NUMBER, getString(R.string._default))
             }
             wallet.unlockWallet(spendingKey.toByteArray())

--- a/app/src/main/java/com/dcrandroid/activities/SaveSeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SaveSeedActivity.kt
@@ -72,7 +72,7 @@ class SaveSeedActivity : BaseActivity() {
         promptWalletPassphrase()
     }
 
-    private fun promptWalletPassphrase(){
+    private fun promptWalletPassphrase() {
 
         val title = PassPromptTitle(R.string.confirm_show_seed, R.string.confirm_show_seed, R.string.confirm_show_seed)
         PassPromptUtil(this, wallet.id, title, allowFingerprint = true) { passDialog, pass ->

--- a/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
@@ -96,7 +96,7 @@ class SplashScreenActivity : BaseActivity() {
         val op = this@SplashScreenActivity.javaClass.name + ": createWallet"
         try {
             val wallet = multiWallet!!.createNewWallet(getString(R.string.mywallet), spendingKey, type)
-            if(Locale.getDefault().language != Locale.ENGLISH.language){
+            if (Locale.getDefault().language != Locale.ENGLISH.language) {
                 wallet.renameAccount(Constants.DEF_ACCOUNT_NUMBER, getString(R.string._default))
             }
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/SplashScreenActivity.kt
@@ -141,6 +141,11 @@ class SplashScreenActivity : BaseActivity() {
         val homeDir = "$filesDir/$walletsDirName"
         walletData.multiWallet = MultiWallet(homeDir, Constants.BADGER_DB, BuildConfig.NetType)
 
+        // set log level
+        val logLevels = resources.getStringArray(R.array.logging_levels)
+        val logLevel = multiWallet!!.readInt32ConfigValueForKey(Dcrlibwallet.LogLevelConfigKey, Constants.DEF_LOG_LEVEL)
+        Dcrlibwallet.setLogLevels(logLevels[logLevel])
+
         if (multiWallet!!.loadedWalletsCount() == 0) {
 
             val v1WalletPath = "$filesDir/$v1WalletDirName/${BuildConfig.NetType}"

--- a/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
+++ b/app/src/main/java/com/dcrandroid/activities/VerifySeedActivity.kt
@@ -71,7 +71,7 @@ class VerifySeedActivity : BaseActivity() {
         }
     }
 
-    private fun verifySeed(){
+    private fun verifySeed() {
 
         val title = PassPromptTitle(R.string.confirm_verify_seed, R.string.confirm_verify_seed, R.string.confirm_verify_seed)
         PassPromptUtil(this, wallet!!.id, title, allowFingerprint = true) { passDialog, pass ->
@@ -105,7 +105,7 @@ class VerifySeedActivity : BaseActivity() {
                         } else if (passDialog is PasswordPromptDialog) {
                             passDialog.showError()
                         }
-                    }else if(e.message == Dcrlibwallet.ErrInvalid) {
+                    } else if (e.message == Dcrlibwallet.ErrInvalid) {
                         passDialog?.dismiss()
                         SnackBar.showError(this@VerifySeedActivity, R.string.seed_verification_failed)
                     } else {

--- a/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
+++ b/app/src/main/java/com/dcrandroid/activities/WalletSettings.kt
@@ -93,6 +93,11 @@ class WalletSettings : BaseActivity() {
 
         remove_wallet.setOnClickListener {
 
+            if (multiWallet!!.isConnectedToDecredNetwork) {
+                SnackBar.showError(this, R.string.disconnect_delete_wallet)
+                return@setOnClickListener
+            }
+
             val dialog = InfoDialog(this)
                     .setDialogTitle(getString(R.string.remove_wallet_prompt))
                     .setMessage(getString(R.string.remove_wallet_message))

--- a/app/src/main/java/com/dcrandroid/data/Transaction.kt
+++ b/app/src/main/java/com/dcrandroid/data/Transaction.kt
@@ -18,18 +18,25 @@ import java.math.BigDecimal
 class Transaction : Serializable {
     @SerializedName("walletID")
     var walletID: Long = 0
+
     @SerializedName("hash")
     var hash: String = ""
+
     @SerializedName("type")
     var type: String = ""
+
     @SerializedName("raw")
     var raw: String = ""
+
     @SerializedName("block_height")
     var height: Int = 0
+
     @SerializedName("direction")
     var direction: Int = 0
+
     @SerializedName("fee")
     var fee: Long = 0
+
     @SerializedName("amount")
     var amount: Long = 0
 
@@ -94,18 +101,23 @@ class Transaction : Serializable {
 
     @SerializedName("outputs")
     var outputs: Array<TransactionOutput>? = null
+
     @SerializedName("inputs")
     var inputs: Array<TransactionInput>? = null
 
     class TransactionInput : Serializable {
         @SerializedName("previous_transaction_index")
         var index: Int = 0
+
         @SerializedName("amount")
         var amount: Long = 0
+
         @SerializedName("account_name")
         var accountName: String? = null
+
         @SerializedName("account_number")
         var accountNumber: Int? = null
+
         @SerializedName("previous_outpoint")
         var previousOutpoint: String? = null
     }
@@ -113,14 +125,19 @@ class Transaction : Serializable {
     class TransactionOutput : Serializable {
         @SerializedName("index")
         var index: Int = 0
+
         @SerializedName("account_number")
         var account: Int = 0
+
         @SerializedName("account_name")
         var accountName: String? = null
+
         @SerializedName("amount")
         var amount: Long = 0
+
         @SerializedName("internal")
         var internal: Boolean = false
+
         @SerializedName("address")
         var address: String? = null
     }

--- a/app/src/main/java/com/dcrandroid/data/Types.kt
+++ b/app/src/main/java/com/dcrandroid/data/Types.kt
@@ -16,6 +16,7 @@ class Accounts : Serializable {
 
     @SerializedName("CurrentBlockHash")
     lateinit var currentBlockHash: String // base64
+
     @SerializedName("CurrentBlockHeight")
     var currentBlockHeight: Int = 0
 
@@ -31,18 +32,25 @@ fun parseAccounts(json: String): Accounts {
 class Account : Serializable {
     @SerializedName("WalletID")
     var walletID: Long = 0
+
     @SerializedName("Number")
     var accountNumber: Int = 0
+
     @SerializedName("Name")
     lateinit var accountName: String
+
     @SerializedName("Balance")
     lateinit var balance: Balance
+
     @SerializedName("TotalBalance")
     var totalBalance: Long = 0
+
     @SerializedName("ExternalKeyCount")
     var externalKeyCount: Int = 0
+
     @SerializedName("InternalKeyCount")
     var internalKeyCount: Int = 0
+
     @SerializedName("ImportedKeyCount")
     var importedKeyCount: Int = 0
 
@@ -75,16 +83,22 @@ fun parseAccountArray(json: String): ArrayList<Account> {
 class Balance : Serializable {
     @SerializedName("Spendable")
     var spendable: Long = 0
+
     @SerializedName("Total")
     var total: Long = 0
+
     @SerializedName("ImmatureReward")
     var immatureReward: Long = 0
+
     @SerializedName("ImmatureStakeGeneration")
     var immatureStakeGeneration: Long = 0
+
     @SerializedName("LockedByTickets")
     var lockedByTickets: Long = 0
+
     @SerializedName("VotingAuthority")
     var votingAuthority: Long = 0
+
     @SerializedName("UnConfirmed")
     var unConfirmed: Long = 0
 

--- a/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/CreateWatchOnlyWallet.kt
@@ -143,8 +143,8 @@ class CreateWatchOnlyWallet(val walletCreated: (wallet: Wallet) -> Unit) : FullS
     private fun toggleUI(enable: Boolean) = GlobalScope.launch(Dispatchers.Main) {
         isCancelable = enable
 
-        walletNameInput!!.setEnabled(enable)
-        extendedPublicKeyInput!!.setEnabled(enable)
+        walletNameInput?.setEnabled(enable)
+        extendedPublicKeyInput?.setEnabled(enable)
         btn_cancel.isEnabled = enable
         if (enable) {
             btn_import.show()

--- a/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/PasswordPromptDialog.kt
@@ -62,7 +62,7 @@ class PasswordPromptDialog(@StringRes val dialogTitle: Int, val isSpending: Bool
 
         if (!processing) {
             btn_confirm.isEnabled = password_input.textString.isNotBlank()
-        }else{
+        } else {
             password_input.setError(null)
         }
     }

--- a/app/src/main/java/com/dcrandroid/dialog/RequestNameDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/RequestNameDialog.kt
@@ -42,7 +42,7 @@ class RequestNameDialog(private val dialogTitle: Int, private val currentName: S
                 setHint(R.string.account_name)
             }
 
-            val filterArray = Array(1) {LengthFilter(MAX_NAME_LENGTH)}
+            val filterArray = Array(1) { LengthFilter(MAX_NAME_LENGTH) }
             editText.filters = filterArray
 
             editText.setSingleLine(true)

--- a/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/AmountInputHelper.kt
@@ -327,7 +327,7 @@ class AmountInputHelper(private val layout: LinearLayout, private val scrollToBo
 }
 
 fun dcrToFormattedUSD(exchangeDecimal: BigDecimal?, dcr: Double, scale: Int = 4): String {
-    if(scale == 4){
+    if (scale == 4) {
         return usdAmountFormat.format(
                 dcrToUSD(exchangeDecimal, dcr)!!.setScale(scale, BigDecimal.ROUND_HALF_EVEN).toDouble())
     }

--- a/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/ConfirmTransaction.kt
@@ -30,7 +30,7 @@ import dcrlibwallet.Wallet
 import kotlinx.android.synthetic.main.confirm_send_sheet.*
 import kotlinx.coroutines.*
 
-class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sendSuccess: () -> Unit) : FullScreenBottomSheetDialog() {
+class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sendSuccess: (shouldExit: Boolean) -> Unit) : FullScreenBottomSheetDialog() {
 
     lateinit var wallet: Wallet
 
@@ -151,10 +151,11 @@ class ConfirmTransaction(private val fragmentActivity: FragmentActivity, val sen
         go_back.isEnabled = false
         isCancelable = false
 
+        sendSuccess(false) // clear estimates
         delay(5000)
         withContext(Dispatchers.Main) {
             dismissAllowingStateLoss()
-            sendSuccess()
+            sendSuccess(true)
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/send/SendDialog.kt
@@ -187,11 +187,13 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
 
         PopupUtil.showPopup(v, items) { window, _ ->
             window.dismiss()
-
-            // clear fields
-            amountHelper.setAmountDCR(0) // clear
-            destinationAddressCard.clear()
+            clearFields()
         }
+    }
+
+    private fun clearFields() {
+        amountHelper.setAmountDCR(0) // clear
+        destinationAddressCard.clear()
     }
 
     override fun showInfo() {
@@ -247,10 +249,15 @@ class SendDialog(val fragmentActivity: FragmentActivity, dismissListener: Dialog
         }, 200)
     }
 
-    private val sendSuccess: () -> Unit = {
+    private val sendSuccess: (shouldExit: Boolean) -> Unit = {
         GlobalScope.launch(Dispatchers.Main) {
-            SnackBar.showText(context!!, R.string.transaction_sent)
-            dismissAllowingStateLoss()
+            if (it) {
+                SnackBar.showText(context!!, R.string.transaction_sent)
+                dismissAllowingStateLoss()
+            } else {
+                clearFields()
+            }
+
         }
     }
 

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/DropdownAdapter.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/DropdownAdapter.kt
@@ -32,7 +32,7 @@ class DropdownAdapter(private val items: Array<DropDownItem>) : RecyclerView.Ada
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.itemView.amount.text = items[position].amount
         holder.itemView.address.text = items[position].address
-        if(items[position].badge.isNotBlank()) {
+        if (items[position].badge.isNotBlank()) {
             holder.itemView.badge.text = items[position].badge
             holder.itemView.badge.show()
         }

--- a/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
+++ b/app/src/main/java/com/dcrandroid/dialog/txdetails/TransactionDetailsDialog.kt
@@ -151,7 +151,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         for (input in transaction.inputs!!) {
             val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(input.amount), input.accountName)
             var inputBadge = ""
-            if (input.accountNumber != null && input.accountNumber != -1){
+            if (input.accountNumber != null && input.accountNumber != -1) {
                 inputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             inputs.add(DropDownItem(amount, input.previousOutpoint!!, inputBadge))
@@ -163,7 +163,7 @@ class TransactionDetailsDialog(val transaction: Transaction) : FullScreenBottomS
         for (output in transaction.outputs!!) {
             val amount = getString(R.string.tx_details_account, CoinFormat.formatDecred(output.amount), output.accountName)
             var outputBadge = ""
-            if (output.account != -1){
+            if (output.account != -1) {
                 outputBadge = multiWallet.walletWithID(transaction.walletID).name
             }
             outputs.add(DropDownItem(amount, output.address!!, outputBadge))

--- a/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/TransactionsFragment.kt
@@ -19,8 +19,6 @@ import com.dcrandroid.adapter.TransactionPageAdapter
 import com.dcrandroid.data.Transaction
 import com.dcrandroid.extensions.hide
 import com.dcrandroid.extensions.show
-import com.dcrandroid.extensions.totalWalletBalance
-import com.dcrandroid.util.CoinFormat
 import com.dcrandroid.util.Deserializer
 import com.google.gson.GsonBuilder
 import dcrlibwallet.Dcrlibwallet
@@ -206,7 +204,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
 
     override fun onTransaction(transactionJson: String?) {
         val transaction = gson.fromJson(transactionJson, Transaction::class.java)
-        if(transaction.walletID == wallet!!.id) {
+        if (transaction.walletID == wallet!!.id) {
             transaction.animate = true
 
             GlobalScope.launch(Dispatchers.Main) {
@@ -218,7 +216,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
     }
 
     override fun onTransactionConfirmed(walletID: Long, hash: String, blockHeight: Int) {
-        if(walletID == wallet!!.id) {
+        if (walletID == wallet!!.id) {
             GlobalScope.launch(Dispatchers.Main) {
                 for (i in 0 until transactions.size) {
                     if (transactions[i].hash == hash) {
@@ -231,7 +229,7 @@ class TransactionsFragment : BaseFragment(), AdapterView.OnItemSelectedListener,
     }
 
     override fun onBlockAttached(walletID: Long, blockHeight: Int) {
-        if(walletID == wallet!!.id) {
+        if (walletID == wallet!!.id) {
             GlobalScope.launch(Dispatchers.Main) {
                 val unconfirmedTransactions = transactions.filter { it.confirmations <= 2 }.count()
                 if (unconfirmedTransactions > 0) {

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -187,7 +187,7 @@ class WalletsFragment : BaseFragment() {
         val op = this@WalletsFragment.javaClass.name + ": createWallet"
         try {
             val wallet = multiWallet.createNewWallet(walletName, spendingKey, type)
-            if(Locale.getDefault().language != Locale.ENGLISH.language){
+            if (Locale.getDefault().language != Locale.ENGLISH.language) {
                 wallet.renameAccount(Constants.DEF_ACCOUNT_NUMBER, getString(R.string._default))
             }
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
+++ b/app/src/main/java/com/dcrandroid/fragments/WalletsFragment.kt
@@ -117,6 +117,9 @@ class WalletsFragment : BaseFragment() {
                             .setPositiveButton(getString(R.string.ok))
                             .show()
                     return false
+                } else if (multiWallet.isConnectedToDecredNetwork) {
+                    SnackBar.showError(context!!, R.string.disconnect_add_wallet)
+                    return false
                 }
 
                 if (activity is HomeActivity) {

--- a/app/src/main/java/com/dcrandroid/view/util/InputConnection.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/InputConnection.kt
@@ -201,7 +201,7 @@ class InputConnectionAccommodatingLatinIMETypeNullIssues(targetView: View?, full
     }
 }
 
-class EditableAccommodatingLatinIMETypeNullIssues() : SpannableStringBuilder("") {
+class EditableAccommodatingLatinIMETypeNullIssues : SpannableStringBuilder("") {
 
     override fun replace(spannableStringStart: Int, spannableStringEnd: Int,
                          replacementSequence: CharSequence?, replacementStart: Int, replacementEnd: Int): SpannableStringBuilder {

--- a/app/src/main/java/com/dcrandroid/view/util/SeedEditTextHelper.kt
+++ b/app/src/main/java/com/dcrandroid/view/util/SeedEditTextHelper.kt
@@ -25,6 +25,7 @@ class SeedEditTextHelper(val layout: SeedEditTextLayout, adapter: SuggestionsTex
     private val editText = layout.seed_et
     private val editTextBackground = layout.list_layout
     private val indexTv = layout.seed_index
+    private val clearBtn = layout.custom_input_clear
 
     lateinit var seedChanged: () -> Unit?
     lateinit var validateSeed: (seedWord: String) -> Boolean
@@ -46,6 +47,10 @@ class SeedEditTextHelper(val layout: SeedEditTextLayout, adapter: SuggestionsTex
         editText.onFocusChangeListener = this
         editText.addTextChangedListener(this)
         editText.onItemClickListener = this
+
+        clearBtn.setOnClickListener {
+            editText.text.clear()
+        }
     }
 
     fun requestFocus(): Int {
@@ -93,7 +98,7 @@ class SeedEditTextHelper(val layout: SeedEditTextLayout, adapter: SuggestionsTex
     }
 
     override fun afterTextChanged(s: Editable?) {
-        val seed = s.toString()
+        clearBtn.visibility = if (s!!.isNotEmpty()) View.VISIBLE else View.INVISIBLE
         seedChanged.invoke()
     }
 

--- a/app/src/main/res/layout/restore_wallet_list_row.xml
+++ b/app/src/main/res/layout/restore_wallet_list_row.xml
@@ -42,8 +42,9 @@
         tools:text="33" />
 
     <AutoCompleteTextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
         android:id="@+id/seed_et"
         android:completionThreshold="2"
         android:background="@null"
@@ -59,6 +60,14 @@
         android:singleLine="true"
         android:nextFocusDown="@id/seed_et"
         tools:text="tolerance" />
+
+        <ImageView
+            android:layout_width="@dimen/margin_padding_size_24"
+            android:layout_height="@dimen/margin_padding_size_24"
+            android:id="@+id/custom_input_clear"
+            android:layout_marginStart="@dimen/margin_padding_size_16"
+            android:visibility="invisible"
+            android:src="@drawable/ic_close" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,5 +533,7 @@
     <string name="date_time_format">MMM dd, yyyy hh:mma</string>
     <string name="watch_only_wallets">Watch-only Wallets</string>
     <string name="wallets_limit_error">Limit of 1 wallet per 1 gig of ram on the device</string>
+    <string name="disconnect_add_wallet">Disconnect/Cancel sync before adding a wallet</string>
+    <string name="disconnect_delete_wallet">Disconnect/Cancel sync before deleting wallet</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,7 +533,7 @@
     <string name="date_time_format">MMM dd, yyyy hh:mma</string>
     <string name="watch_only_wallets">Watch-only Wallets</string>
     <string name="wallets_limit_error">Limit of 1 wallet per 1 gig of ram on the device</string>
-    <string name="disconnect_add_wallet">Disconnect/Cancel sync before adding a wallet</string>
-    <string name="disconnect_delete_wallet">Disconnect/Cancel sync before deleting wallet</string>
+    <string name="disconnect_add_wallet">Disconnect/cancel sync before adding a wallet</string>
+    <string name="disconnect_delete_wallet">Disconnect/cancel sync before deleting wallet</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
         <item name="colorSecondary">@color/turquoise</item>
         <item name="colorControlHighlight">@color/whiteRipple</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
-        <item name="android:navigationBarColor" tools:targetApi="21">@android:color/white</item>
+        <item name="android:navigationBarColor">@android:color/white</item>
         <item name="android:textColor">@color/blackFirstTextColor</item>
         <item name="textInputStyle">@style/Widget.Design.TextInputLayout</item>
     </style>


### PR DESCRIPTION
- Beep only once per block(each wallet sends a block attached notification).
- Set log level at app startup.
- Require user to cancel sync before creating/deleting wallet.
- Clear send page content after a successful transaction.
- Add a clear button to restore the wallet seed input field.